### PR TITLE
SpreadsheetEngine added new methods: delete/insert row/column.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetFormula.java
@@ -20,6 +20,8 @@ package walkingkooka.spreadsheet;
 
 import walkingkooka.*;
 import walkingkooka.test.*;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetFunctionName;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserToken;
 import walkingkooka.tree.expression.*;
 
 import java.util.*;
@@ -29,8 +31,21 @@ import java.util.*;
  */
 public final class SpreadsheetFormula implements HashCodeEqualsDefined, Value<String> {
 
+    /**
+     * A function that replaces cell references with expressions that become invalid due to a deleted row or column.
+     */
+    public final static SpreadsheetFunctionName INVALID_CELL_REFERENCE = SpreadsheetFunctionName.with("InvalidCellReference");
+
+    /**
+     * A {@link SpreadsheetParserToken} that holds the {@link #INVALID_CELL_REFERENCE} function name.
+     */
+    public final static SpreadsheetParserToken INVALID_CELL_REFERENCE_PARSER_TOKEN = SpreadsheetParserToken.functionName(INVALID_CELL_REFERENCE, INVALID_CELL_REFERENCE.toString());
+
+    /**
+     * Factory that creates a new {@link SpreadsheetFormula}
+     */
     public static SpreadsheetFormula with(final String value) {
-        Objects.requireNonNull(value, "value");
+        checkValue(value);
 
         return new SpreadsheetFormula(value);
     }
@@ -48,7 +63,22 @@ public final class SpreadsheetFormula implements HashCodeEqualsDefined, Value<St
         return this.value;
     }
 
+    public SpreadsheetFormula setValue(final String value) {
+        checkValue(value);
+        return this.value.equals(value) ?
+               this :
+               this.replace(value);
+    }
+
     private String value;
+
+    private static void checkValue(final String value) {
+        Objects.requireNonNull(value, "value");
+    }
+
+    private static SpreadsheetFormula replace(final String value) {
+        return new SpreadsheetFormula(value);
+    }
 
     // HashCodeEqualsDefined..........................................................................................
 

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteColumnOrRow.java
@@ -1,0 +1,64 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.spreadsheet.SpreadsheetLabelMapping;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+
+/**
+ * Deletes the selected columns or rows.
+ */
+final class BasicSpreadsheetEngineDeleteColumnOrRow extends BasicSpreadsheetEngineDeleteOrInsertColumnOrRow {
+
+    static void delete(final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        new BasicSpreadsheetEngineDeleteColumnOrRow(columnOrRow).delete0();
+    }
+
+    private BasicSpreadsheetEngineDeleteColumnOrRow(final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        super(columnOrRow);
+    }
+
+    /**
+     * Delete the selected columns or rows.
+     */
+    private void delete0() {
+        this.columnOrRow.delete(this.columnOrRow.value, this.columnOrRow.count);
+        this.move();
+        this.columnOrRow.fixAllExpressionCellReferences();
+        ;
+        this.columnOrRow.fixAllLabelMappings();
+    }
+
+    private void move() {
+        final int offset = this.columnOrRow.value + this.columnOrRow.count;
+        final int moveCount = this.columnOrRow.max() - offset;
+
+        for (int i = 0; i <= moveCount; i++) {
+            this.columnOrRow.move(offset + i);
+        }
+    }
+
+    @Override
+    boolean isDeletedReference(final SpreadsheetColumnReferenceParserToken column) {
+        return this.isDeletedReference(column.value().value());
+    }
+
+    @Override
+    boolean isDeletedReference(final SpreadsheetRowReferenceParserToken row) {
+        return this.isDeletedReference(row.value().value());
+    }
+
+    private boolean isDeletedReference(final int value) {
+        final int deleted = this.columnOrRow.value;
+        return deleted <= value && value <= deleted + this.columnOrRow.count;
+    }
+
+    @Override
+    int fixReferenceOffset(final int count) {
+        return -count;
+    }
+
+    @Override
+    void fixLabelMapping(final SpreadsheetLabelMapping mapping) {
+        this.columnOrRow.deleteFixReference(mapping);
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRow.java
@@ -1,0 +1,28 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.spreadsheet.SpreadsheetLabelMapping;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+
+/**
+ * Template that includes most of the methods that may be used to delete or insert columns or rows,
+ * including fixing of cell references.
+ */
+abstract class BasicSpreadsheetEngineDeleteOrInsertColumnOrRow {
+
+    BasicSpreadsheetEngineDeleteOrInsertColumnOrRow(final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        super();
+        this.columnOrRow = columnOrRow;
+        columnOrRow.deleteOrInsert = this;
+    }
+
+    abstract boolean isDeletedReference(final SpreadsheetColumnReferenceParserToken row);
+
+    abstract boolean isDeletedReference(final SpreadsheetRowReferenceParserToken row);
+
+    abstract int fixReferenceOffset(final int count);
+
+    abstract void fixLabelMapping(final SpreadsheetLabelMapping mapping);
+
+    final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow;
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.java
@@ -1,0 +1,85 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Performs operations on columns for delete or insertion.
+ */
+final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn extends BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
+
+    static BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn with(final int value,
+                                                                      final int count,
+                                                                      final BasicSpreadsheetEngine engine) {
+        return new BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn(value, count, engine);
+    }
+
+    /**
+     * Private ctor use static factory.
+     */
+    private BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn(final int value,
+                                                                  final int count,
+                                                                  final BasicSpreadsheetEngine engine) {
+        super(value, count, engine);
+    }
+
+    @Override
+    int max() {
+        return this.cellStore().columns();
+    }
+
+    @Override
+    Collection<SpreadsheetCell> cells(final int column) {
+        return this.cellStore().column(column);
+    }
+
+    @Override
+    SpreadsheetParserToken fixCellReferencesWithinExpression(final SpreadsheetParserToken token) {
+        return BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.expressionFixReferences(token,
+                this);
+    }
+
+    @Override
+    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token) {
+        return this.deleteOrInsert.isDeletedReference(token) ?
+                INVALID_CELL_REFERENCE :
+                this.fixCellReferencesWithinExpression0(token);
+    }
+
+    private Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression0(final SpreadsheetColumnReferenceParserToken token) {
+        final SpreadsheetColumnReference old = token.value();
+        final int value = old.value();
+
+        SpreadsheetColumnReferenceParserToken result = token;
+
+        if (value > this.value) {
+            final SpreadsheetColumnReference reference = old.setValue(value + this.deleteOrInsert.fixReferenceOffset(this.count));
+            result = SpreadsheetParserToken.columnReference(reference, reference.toString());
+        }
+
+        return Optional.of(result);
+    }
+
+    @Override
+    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token) {
+        // only fixing cols refs not rows
+        return Optional.of(token);
+    }
+
+    @Override
+    SpreadsheetCellReference fixCellReference(final SpreadsheetCellReference reference) {
+        return reference.add(this.deleteOrInsert.fixReferenceOffset(this.count), 0);
+    }
+
+    @Override
+    int columnOrRowValue(final SpreadsheetCellReference cell) {
+        return cell.column().value();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.java
@@ -1,0 +1,260 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.spreadsheet.SpreadsheetLabelMapping;
+import walkingkooka.spreadsheet.store.cell.SpreadsheetCellStore;
+import walkingkooka.spreadsheet.store.label.SpreadsheetLabelStore;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Base class that acts as a bridge to either columns or rows.
+ */
+abstract class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
+
+    /**
+     * Package private to limit sub classing.
+     */
+    BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow(final int value,
+                                                               final int count,
+                                                               final BasicSpreadsheetEngine engine) {
+        super();
+        this.value = value;
+        this.count = count;
+        this.engine = engine;
+    }
+
+    final void delete() {
+        BasicSpreadsheetEngineDeleteColumnOrRow.delete(this);
+    }
+
+    final void insert() {
+        BasicSpreadsheetEngineInsertColumnOrRow.insert(this);
+    }
+
+    // delete....................................................................................................
+
+    /**
+     * Deletes the selected range of row or columns.
+     */
+    final void delete(final int start, final int count) {
+        for (int i = 0; i < count; i++) {
+            this.delete(start + i);
+        }
+    }
+
+    /**
+     * Delete all the cells in the selected row/column.
+     */
+    final void delete(final int columnOrRow) {
+        this.cells(columnOrRow).stream()
+                .forEach(c -> this.cellStore().delete(c.reference()));
+    }
+
+    // copy .............................................................................................................
+
+    /**
+     * Moves all the cells in the selected row/column.
+     */
+    final void move(final int source) {
+        this.cells(source).stream()
+                .forEach(this::moveCell);
+    }
+
+    /**
+     * Moves the cell to its new location, expressions will be updated later.
+     */
+    private void moveCell(final SpreadsheetCell cell) {
+        final SpreadsheetCellReference reference = cell.reference();
+        this.deleteCell(reference);
+        this.saveCell(cell.setReference(this.fixCellReference(cell.reference())));
+    }
+
+    // fix references in all cells .............................................................................
+
+    /**
+     * Scans all cell expressions for references and fixes those needing fixing.
+     */
+    final void fixAllExpressionCellReferences() {
+        final int rows = this.maxRow();
+        for (int i = 0; i <= rows; i++) {
+            this.fixRowCellReferences(i);
+        }
+    }
+
+    private void fixRowCellReferences(final int row) {
+        this.rowCells(row).stream()
+                .map(this::fixExpressionCellReferences)
+                .forEach(this::saveCell);
+    }
+
+    /**
+     * Attempts to parse the formula if necessary and then update cell references that may have shifted due to a
+     * delete or insert.
+     */
+    private SpreadsheetCell fixExpressionCellReferences(final SpreadsheetCell cell) {
+        return this.engine.parse(cell, this::fixCellReferencesWithinExpression);
+    }
+
+    /**
+     * Attempts to parse the formula if necessary and then update cell references that may have shifted due to a
+     * delete or insert. Note that references to deleted cells, will be replaced by a function that when executed
+     * reports an error that the cell was deleted.
+     */
+    abstract SpreadsheetParserToken fixCellReferencesWithinExpression(final SpreadsheetParserToken token);
+
+    /**
+     * Returned when the input reference was deleted.
+     */
+    final static Optional<SpreadsheetParserToken> INVALID_CELL_REFERENCE = Optional.empty();
+
+    /**
+     * Handles a column {@link SpreadsheetColumnReferenceParserToken} within an expression.
+     * It may be returned unmodified, replaced by a function if the reference was deleted or simply have the reference adjusted.
+     */
+    abstract Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token);
+
+    /**
+     * Handles a column {@link SpreadsheetRowReferenceParserToken} within an expression.
+     * It may be returned unmodified, replaced by a function if the reference was deleted or simply have the reference adjusted.
+     */
+    abstract Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token);
+
+    /**
+     * Returns a function that when executed will report that the original cell reference was deleted.
+     */
+    final SpreadsheetParserToken cellReferenceDeleted(final SpreadsheetParserToken token) {
+        final String message = token.text();
+
+        final List<ParserToken> tokens = Lists.of(SpreadsheetFormula.INVALID_CELL_REFERENCE_PARSER_TOKEN,
+                SpreadsheetParserToken.openParenthesisSymbol("(", "("),
+                SpreadsheetParserToken.text(message, message),
+                SpreadsheetParserToken.openParenthesisSymbol(")", ")"));
+        return SpreadsheetParserToken.function(tokens, ParserToken.text(tokens));
+    }
+
+    /**
+     * Adjusts the reference to match the delete or insert column/row value to it still points to the "same" cell.
+     */
+    abstract SpreadsheetCellReference fixCellReference(final SpreadsheetCellReference reference);
+
+//    // cell reference.................................................................................................
+
+    /**
+     * Returns the row or column int value
+     */
+    abstract int columnOrRowValue(final SpreadsheetCellReference cell);
+
+    // label mappings............................................................................................
+
+    // fix references in all label mappings .............................................................................
+
+    /**
+     * Visits all label mappings and adjusts the given references.
+     */
+    final void fixAllLabelMappings() {
+        this.labelStore().all()
+                .stream()
+                .filter(this::shouldProcessLabelMapping)
+                .forEach(this.deleteOrInsert::fixLabelMapping);
+    }
+
+    /**
+     * Filter only columns or rows that will be deleted or inserted.
+     */
+    private boolean shouldProcessLabelMapping(final SpreadsheetLabelMapping mapping) {
+        return this.columnOrRowValue(mapping.cell()) >= this.value;
+    }
+
+    /**
+     * Deletes the mapping because the target was deleted or fixes the reference.
+     */
+    final void deleteFixReference(final SpreadsheetLabelMapping mapping) {
+        if (this.columnOrRowValue(mapping.cell()) >= this.value + this.count) {
+            this.fixReferenceAndSave(mapping);
+        } else {
+            this.labelStore().delete(mapping.label());
+        }
+    }
+
+    /**
+     * Fixes a mapping because the target was moved because of inserted columns or rows.
+     */
+    final void insertFixReference(final SpreadsheetLabelMapping mapping) {
+        this.fixReferenceAndSave(mapping);
+    }
+
+    private void fixReferenceAndSave(final SpreadsheetLabelMapping mapping) {
+        this.saveLabel(mapping.setCell(this.fixCellReference(mapping.cell())));
+    }
+
+    // cells....................................................................................................
+
+    /**
+     * Returns the max column or row.
+     */
+    abstract int max();
+
+    /**
+     * Returns the max or last row
+     */
+    final int maxRow() {
+        return this.cellStore().rows();
+    }
+
+    /**
+     * Find all the cells int the given column/row.
+     */
+    abstract Collection<SpreadsheetCell> cells(final int columnOrRow);
+
+    /**
+     * Returns all the cells for the requested row.
+     */
+    final Collection<SpreadsheetCell> rowCells(final int row) {
+        return this.cellStore().row(row);
+    }
+
+    /**
+     * Deletes the cell.
+     */
+    final void deleteCell(final SpreadsheetCellReference cell) {
+        this.cellStore().delete(cell);
+    }
+
+    /**
+     * Saves the cell.
+     */
+    final void saveCell(final SpreadsheetCell cell) {
+        this.cellStore().save(cell);
+    }
+
+    final SpreadsheetCellStore cellStore() {
+        return this.engine.cellStore;
+    }
+
+    final int value;
+    final int count;
+
+    // labels....................................................................................................
+
+    final void saveLabel(final SpreadsheetLabelMapping mapping) {
+        this.labelStore().save(mapping);
+    }
+
+    final SpreadsheetLabelStore labelStore() {
+        return this.engine.labelStore;
+    }
+
+    private final BasicSpreadsheetEngine engine;
+
+    BasicSpreadsheetEngineDeleteOrInsertColumnOrRow deleteOrInsert;
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.java
@@ -1,0 +1,85 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.spreadsheet.SpreadsheetCell;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Performs operations on rows for delete or insertion.
+ */
+final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow extends BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow {
+
+    static BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow with(final int value,
+                                                                   final int count,
+                                                                   final BasicSpreadsheetEngine engine) {
+        return new BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow(value, count, engine);
+    }
+
+    /**
+     * Private ctor use static factory.
+     */
+    private BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow(final int value,
+                                                               final int count,
+                                                               final BasicSpreadsheetEngine engine) {
+        super(value, count, engine);
+    }
+
+    @Override
+    final int max() {
+        return this.maxRow();
+    }
+
+    @Override
+    final Collection<SpreadsheetCell> cells(final int row) {
+        return this.rowCells(row);
+    }
+
+    @Override
+    SpreadsheetParserToken fixCellReferencesWithinExpression(final SpreadsheetParserToken token) {
+        return BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.expressionFixReferences(token,
+                this);
+    }
+
+    @Override
+    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetColumnReferenceParserToken token) {
+        // only fixing rows refs not cols
+        return Optional.of(token);
+    }
+
+    @Override
+    Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression(final SpreadsheetRowReferenceParserToken token) {
+        return this.deleteOrInsert.isDeletedReference(token) ?
+                INVALID_CELL_REFERENCE :
+                this.fixCellReferencesWithinExpression0(token);
+    }
+
+    private Optional<SpreadsheetParserToken> fixCellReferencesWithinExpression0(final SpreadsheetRowReferenceParserToken token) {
+        final SpreadsheetRowReference old = token.value();
+        final int value = old.value();
+
+        SpreadsheetRowReferenceParserToken result = token;
+
+        if (value > this.value) {
+            final SpreadsheetRowReference reference = old.setValue(value + this.deleteOrInsert.fixReferenceOffset(this.count));
+            result = SpreadsheetParserToken.rowReference(reference, reference.toString());
+        }
+
+        return Optional.of(result);
+    }
+
+    @Override
+    SpreadsheetCellReference fixCellReference(final SpreadsheetCellReference reference) {
+        return reference.add(0, this.deleteOrInsert.fixReferenceOffset(this.count));
+    }
+
+    @Override
+    final int columnOrRowValue(final SpreadsheetCellReference cell) {
+        return cell.row().value();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineInsertColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineInsertColumnOrRow.java
@@ -1,0 +1,59 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.spreadsheet.SpreadsheetLabelMapping;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+
+/**
+ * Inserts the requested columns or rows.
+ */
+final class BasicSpreadsheetEngineInsertColumnOrRow extends BasicSpreadsheetEngineDeleteOrInsertColumnOrRow {
+
+    static void insert(final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        new BasicSpreadsheetEngineInsertColumnOrRow(columnOrRow).insert0();
+    }
+
+    private BasicSpreadsheetEngineInsertColumnOrRow(final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        super(columnOrRow);
+    }
+
+    /**
+     * Inserts the requested number of columns or rows.
+     */
+    private void insert0() {
+        this.move();
+        this.columnOrRow.fixAllExpressionCellReferences();
+        ;
+        this.columnOrRow.fixAllLabelMappings();
+    }
+
+    private void move() {
+        final int value = this.columnOrRow.value;
+        final int moveCount = this.columnOrRow.max() - value;
+        final int offset = value;
+
+        for (int i = 0; i <= moveCount; i++) {
+            this.columnOrRow.move(offset + moveCount - i);
+        }
+    }
+
+    @Override
+    int fixReferenceOffset(final int count) {
+        return +count;
+    }
+
+    @Override
+    boolean isDeletedReference(final SpreadsheetColumnReferenceParserToken column) {
+        return false; // no references are ever deleted during an insert.
+    }
+
+    @Override
+    boolean isDeletedReference(final SpreadsheetRowReferenceParserToken row) {
+        return false; // no references are ever deleted during an insert.
+    }
+
+    @Override
+    void fixLabelMapping(final SpreadsheetLabelMapping mapping) {
+        this.columnOrRow.insertFixReference(mapping);
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.java
@@ -1,0 +1,510 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.collect.list.Lists;
+import walkingkooka.collect.stack.Stack;
+import walkingkooka.collect.stack.Stacks;
+import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.text.cursor.parser.ParentParserToken;
+import walkingkooka.text.cursor.parser.ParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetAdditionParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetBetweenSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetBigDecimalParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetBigIntegerParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCloseParenthesisSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetDivideSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetDivisionParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetDoubleParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetEqualsParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetEqualsSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetFunctionNameParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetFunctionParameterSeparatorSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetFunctionParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetGreaterThanEqualsParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetGreaterThanEqualsSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetGreaterThanParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetGreaterThanSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetGroupParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelNameParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLessThanEqualsParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLessThanEqualsSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLessThanParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLessThanSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLocalDateParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLocalDateTimeParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLocalTimeParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLongParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetMinusSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetMultiplicationParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetMultiplySymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetNegativeParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetNotEqualsParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetNotEqualsSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetOpenParenthesisSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserTokenVisitor;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetPercentSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetPercentageParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetPlusSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetPowerParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetPowerSymbolParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRangeParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReferenceParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetSubtractionParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetTextParserToken;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetWhitespaceParserToken;
+import walkingkooka.tree.visit.Visiting;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A {@link SpreadsheetParserTokenVisitor} that handles visiting and updating {@link SpreadsheetCellReferenceParserToken}
+ * so cell references after an insert or delete row/column are corrected.
+ */
+final class BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor extends SpreadsheetParserTokenVisitor {
+
+    /**
+     * Accepts a token tree and updates rows and columns.
+     */
+    static SpreadsheetParserToken expressionFixReferences(final SpreadsheetParserToken token,
+                                                          final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        final BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor visitor = new BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor(columnOrRow);
+        visitor.accept(token);
+
+        final List<SpreadsheetParserToken> tokens = visitor.children;
+        final int count = tokens.size();
+        if (1 != count) {
+            throw new IllegalStateException("Expected only 1 child but got " + count + "=" + tokens);
+        }
+
+        return tokens.get(0);
+    }
+
+    /**
+     * Package private ctor use static method.
+     */
+    // @VisibleForTesting
+    BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor(final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow) {
+        super();
+        this.columnOrRow = columnOrRow;
+    }
+
+    private final BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow columnOrRow;
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetAdditionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetAdditionParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetCellReferenceParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetCellReferenceParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetDivisionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetDivisionParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetEqualsParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetFunctionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetFunctionParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetGreaterThanParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetGreaterThanParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetGreaterThanEqualsParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetGroupParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetGroupParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetLessThanParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetLessThanParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetLessThanEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetLessThanEqualsParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetMultiplicationParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetMultiplicationParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetNegativeParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetNegativeParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetNotEqualsParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetNotEqualsParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetPercentageParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetPercentageParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetPowerParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetPowerParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetRangeParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetRangeParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    @Override
+    protected final Visiting startVisit(final SpreadsheetSubtractionParserToken token) {
+        this.enter();
+        return super.startVisit(token);
+    }
+
+    @Override
+    protected final void endVisit(final SpreadsheetSubtractionParserToken token) {
+        this.exit(token);
+        super.endVisit(token);
+    }
+
+    // leaf ......................................................................................................
+
+    @Override
+    protected final void visit(final SpreadsheetBetweenSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetBigDecimalParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetBigIntegerParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetCloseParenthesisSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetColumnReferenceParserToken token) {
+        this.leaf(this.columnOrRow.fixCellReferencesWithinExpression(token));
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetDivideSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetDoubleParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetFunctionNameParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetFunctionParameterSeparatorSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetGreaterThanSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetGreaterThanEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLabelNameParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLessThanSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLessThanEqualsSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLocalDateParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLocalDateTimeParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLocalTimeParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetLongParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetMinusSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetMultiplySymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetNotEqualsSymbolParserToken token) {
+        this.leaf(token);
+        super.visit(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetOpenParenthesisSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetPercentSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetPlusSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetPowerSymbolParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetRowReferenceParserToken token) {
+        this.leaf(this.columnOrRow.fixCellReferencesWithinExpression(token));
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetTextParserToken token) {
+        this.leaf(token);
+    }
+
+    @Override
+    protected final void visit(final SpreadsheetWhitespaceParserToken token) {
+        this.leaf(token);
+    }
+
+    private void enter() {
+        this.previousChildren = this.previousChildren.push(this.children);
+        this.children = Lists.array();
+        this.invalidCellReference = false;
+    }
+
+    private <P extends SpreadsheetParserToken & ParentParserToken> void exit(final P parent) {
+        final List<SpreadsheetParserToken> children = this.children;
+        this.children = this.previousChildren.peek();
+        this.previousChildren = this.previousChildren.pop();
+        this.add(
+                this.invalidCellReference ?
+                        this.cellReferenceDeleted(parent) :
+                        SpreadsheetParserToken.class.cast(parent.setValue(children).setTextFromValues()));
+        this.invalidCellReference = false;
+    }
+
+    /**
+     * When true, the parent {@link SpreadsheetParserToken} which should be a {@link SpreadsheetCellReferenceParserToken}
+     * will be replaced by {@link #cellReferenceDeleted(SpreadsheetParserToken)}.
+     */
+    private boolean invalidCellReference = false;
+
+    /**
+     * Returns a function that when executed will report that the original cell reference was deleted.
+     */
+    private SpreadsheetParserToken cellReferenceDeleted(final SpreadsheetParserToken token) {
+        final String message = token.text();
+
+        final List<ParserToken> tokens = Lists.of(SpreadsheetFormula.INVALID_CELL_REFERENCE_PARSER_TOKEN,
+                SpreadsheetParserToken.openParenthesisSymbol("(", "("),
+                SpreadsheetParserToken.text(message, message),
+                SpreadsheetParserToken.openParenthesisSymbol(")", ")"));
+        return SpreadsheetParserToken.function(tokens, ParserToken.text(tokens));
+    }
+
+    private void leaf(final Optional<SpreadsheetParserToken> token) {
+        if (token.isPresent()) {
+            this.add(token.get());
+        } else {
+            this.invalidCellReference = true;
+        }
+    }
+
+    private void leaf(final SpreadsheetParserToken token) {
+        this.add(token);
+    }
+
+    private void add(final SpreadsheetParserToken child) {
+        Objects.requireNonNull(child, "child");
+        this.children.add(child);
+    }
+
+    private Stack<List<SpreadsheetParserToken>> previousChildren = Stacks.arrayList();
+
+    private List<SpreadsheetParserToken> children = Lists.array();
+
+    @Override
+    public final String toString() {
+        return this.children + "," + this.previousChildren;
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/FakeSpreadsheetEngine.java
@@ -4,7 +4,8 @@ import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.test.Fake;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
-import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
 
 import java.util.Optional;
 
@@ -16,6 +17,26 @@ public class FakeSpreadsheetEngine implements SpreadsheetEngine, Fake {
 
     @Override
     public Optional<SpreadsheetCell> loadCell(final SpreadsheetCellReference cell, final SpreadsheetEngineLoading loading) {
+        throw new UnsupportedOperationException();
+    }
+    
+    @Override
+    public void deleteColumns(final SpreadsheetColumnReference column, final int count) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteRows(final SpreadsheetRowReference row, final int count) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insertColumns(final SpreadsheetColumnReference column, final int count) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void insertRows(final SpreadsheetRowReference row, final int count) {
         throw new UnsupportedOperationException();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngine.java
@@ -3,7 +3,8 @@ package walkingkooka.spreadsheet.engine;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetId;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
-import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
 
 import java.util.Optional;
 
@@ -22,4 +23,24 @@ public interface SpreadsheetEngine {
      * Invalid cell requests will be ignored and absent fromthe result. If parsing or evaluation fails the cell will have an error.
      */
     Optional<SpreadsheetCell> loadCell(final SpreadsheetCellReference cell, final SpreadsheetEngineLoading loading);
+
+    /**
+     * Deletes the identified columns, updates all absolute references as necessary in both formulas and label mappings.
+     */
+    void deleteColumns(final SpreadsheetColumnReference column, final int count);
+
+    /**
+     * Deletes the identified rows, updates all absolute references as necessary in both formulas and label mappings.
+     */
+    void deleteRows(final SpreadsheetRowReference row, final int count);
+
+    /**
+     * Inserts the identified columns, updates all absolute references as necessary in both formulas and label mappings.
+     */
+    void insertColumns(final SpreadsheetColumnReference column, final int count);
+
+    /**
+     * Inserts the identified rows, updates all absolute references as necessary in both formulas and label mappings.
+     */
+    void insertRows(final SpreadsheetRowReference row, final int count);
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngines.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngines.java
@@ -23,10 +23,16 @@ public final class SpreadsheetEngines implements PublicStaticHelper {
      */
     public static SpreadsheetEngine basic(final SpreadsheetId id,
                                           final SpreadsheetCellStore cellStore,
+                                          final SpreadsheetLabelStore labelStore,
                                           final Parser<SpreadsheetParserToken, SpreadsheetParserContext> parser,
                                           final SpreadsheetParserContext parserContext,
                                           final Function<SpreadsheetEngine, ExpressionEvaluationContext> evaluationContextFactory) {
-        return BasicSpreadsheetEngine.with(id, cellStore, parser, parserContext, evaluationContextFactory);
+        return BasicSpreadsheetEngine.with(id,
+                cellStore,
+                labelStore,
+                parser,
+                parserContext,
+                evaluationContextFactory);
     }
 
     /**

--- a/src/main/java/walkingkooka/spreadsheet/store/label/BasicSpreadsheetLabelStore.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/label/BasicSpreadsheetLabelStore.java
@@ -1,11 +1,13 @@
 package walkingkooka.spreadsheet.store.label;
 
+import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.map.Maps;
 import walkingkooka.spreadsheet.SpreadsheetLabelMapping;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,7 +57,9 @@ final class BasicSpreadsheetLabelStore implements SpreadsheetLabelStore {
 
     @Override
     public Collection<SpreadsheetLabelMapping> all() {
-        return Collections.unmodifiableCollection(this.mappings.values());
+        final List<SpreadsheetLabelMapping> copy = Lists.array();
+        copy.addAll(this.mappings.values());
+        return Collections.unmodifiableCollection(copy);
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetFormulaTest.java
@@ -18,14 +18,58 @@ public final class SpreadsheetFormulaTest extends PublicClassTestCase<Spreadshee
 
     @Test
     public void testWith() {
-        final SpreadsheetFormula formula = SpreadsheetFormula.with(VALUE);
-        assertEquals("value(ExpressionNode)", VALUE, formula.value());
+        final SpreadsheetFormula formula = this.create();
+        this.checkValue(formula, VALUE);
+    }
+
+    @Test
+    public void testWithEmpty() {
+        final String value = "";
+        final SpreadsheetFormula formula = SpreadsheetFormula.with(value);
+        this.checkValue(formula, value);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testSetValueNullFails() {
+        this.create().setValue(null);
+    }
+
+    @Test
+    public void testSetValueSame() {
+        final SpreadsheetFormula formula = this.create();
+        assertSame(formula, formula.setValue(VALUE));
+    }
+
+    @Test
+    public void testSetValueDifferent() {
+        this.setValueAndCheck("different");
+    }
+
+    @Test
+    public void testSetValueDifferentEmpty() {
+        this.setValueAndCheck("");
+    }
+
+    private void setValueAndCheck(final String differentValue) {
+        final SpreadsheetFormula formula = this.create();
+        final SpreadsheetFormula different = formula.setValue(differentValue);
+        assertNotSame(formula, different);
+        this.checkValue(different, differentValue);
     }
 
     @Test
     public void testToString() {
         assertEquals("" + VALUE, SpreadsheetFormula.with(VALUE).toString());
     }
+
+    private SpreadsheetFormula create() {
+        return SpreadsheetFormula.with(VALUE);
+    }
+
+    private void checkValue(final SpreadsheetFormula formula, final String value) {
+        assertEquals("value(ExpressionNode)", value, formula.value());
+    }
+
 
     @Override
     protected Class<SpreadsheetFormula> type() {

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteColumnOrRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteColumnOrRowTest.java
@@ -1,0 +1,10 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class BasicSpreadsheetEngineDeleteColumnOrRowTest extends PackagePrivateClassTestCase<BasicSpreadsheetEngineDeleteColumnOrRow> {
+    @Override
+    protected Class<BasicSpreadsheetEngineDeleteColumnOrRow> type() {
+        return BasicSpreadsheetEngineDeleteColumnOrRow.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRowTest.java
@@ -1,0 +1,10 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRowTest extends PackagePrivateClassTestCase<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow> {
+    @Override
+    protected Class<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow> type() {
+        return BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnOrRow.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnTest.java
@@ -1,0 +1,10 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumnTest extends PackagePrivateClassTestCase<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn> {
+    @Override
+    protected Class<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn> type() {
+        return BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRowTest.java
@@ -1,0 +1,10 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRowTest extends PackagePrivateClassTestCase<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow> {
+    @Override
+    protected Class<BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow> type() {
+        return BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowTest.java
@@ -1,0 +1,10 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.test.PackagePrivateClassTestCase;
+
+public final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowTest extends PackagePrivateClassTestCase<BasicSpreadsheetEngineDeleteOrInsertColumnOrRow> {
+    @Override
+    protected Class<BasicSpreadsheetEngineDeleteOrInsertColumnOrRow> type() {
+        return BasicSpreadsheetEngineDeleteOrInsertColumnOrRow.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest.java
@@ -1,0 +1,21 @@
+package walkingkooka.spreadsheet.engine;
+
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserTokenVisitorTestCase;
+
+public final class BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitorTest extends SpreadsheetParserTokenVisitorTestCase<BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> {
+
+    @Override
+    protected BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor createParserTokenVisitor() {
+        return new BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor(BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.with(0, 0, null));
+    }
+
+    @Override
+    protected String requiredNamePrefix() {
+        return BasicSpreadsheetEngine.class.getSimpleName();
+    }
+
+    @Override
+    protected Class<BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor> parserTokenVisitorType() {
+        return BasicSpreadsheetEngineSpreadsheetCellReferenceFixerSpreadsheetParserTokenVisitor.class;
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -13,12 +13,15 @@ import walkingkooka.spreadsheet.store.label.SpreadsheetLabelStores;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.Parsers;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserContext;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserContexts;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParserToken;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParsers;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetReferenceKind;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
 import walkingkooka.tree.expression.ExpressionEvaluationContext;
+import walkingkooka.tree.expression.ExpressionEvaluationException;
 import walkingkooka.tree.expression.ExpressionNodeName;
 
 import java.math.BigInteger;
@@ -26,6 +29,7 @@ import java.math.MathContext;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
@@ -35,27 +39,32 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
     @Test(expected = NullPointerException.class)
     public void testNullIdFails() {
-        BasicSpreadsheetEngine.with(null, this.cellStore(), this.parser(), this.parserContext(), this.evaluationContextFactory());
+        BasicSpreadsheetEngine.with(null, this.cellStore(), this.labelStore(), this.parser(), this.parserContext(), this.evaluationContextFactory());
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullCellStoreFails() {
-        BasicSpreadsheetEngine.with(this.id(), null, this.parser(), this.parserContext(), this.evaluationContextFactory());
+        BasicSpreadsheetEngine.with(this.id(), null, this.labelStore(), this.parser(), this.parserContext(), this.evaluationContextFactory());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullLabelStoreFails() {
+        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), null,this.parser(), this.parserContext(), this.evaluationContextFactory());
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullParserFails() {
-        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), null, this.parserContext(), this.evaluationContextFactory());
+        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), this.labelStore(),null, this.parserContext(), this.evaluationContextFactory());
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullParserContextFails() {
-        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), this.parser(), null, this.evaluationContextFactory());
+        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), this.labelStore(), this.parser(), null, this.evaluationContextFactory());
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullEvaluationContextFactoryFails() {
-        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), this.parser(), this.parserContext(), null);
+        BasicSpreadsheetEngine.with(this.id(), this.cellStore(), this.labelStore(), this.parser(), this.parserContext(), null);
     }
 
     @Test
@@ -84,7 +93,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         final SpreadsheetCellReference cellReference = this.cellReference(1, 1);
         cellStore.save(SpreadsheetCell.with(cellReference, SpreadsheetFormula.with("1+2")));
 
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 cellReference,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(1+2));
@@ -174,15 +183,15 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         cellStore.save(SpreadsheetCell.with(b, SpreadsheetFormula.with("3+4")));
         cellStore.save(SpreadsheetCell.with(c, SpreadsheetFormula.with("5+6")));
 
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(1+2));
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 b,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(3+4));
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 c,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(5+6));
@@ -222,13 +231,13 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         cellStore.save(SpreadsheetCell.with(b, SpreadsheetFormula.with("3+4")));
 
         // formula
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 b,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(3+4));
 
         // reference to B1 which has formula
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(3+4));
@@ -249,18 +258,1275 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         labelStore.save(SpreadsheetLabelMapping.with(LABEL, b));
 
         // formula
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 b,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(3+4));
 
         // reference to B1 which has formula
-        this.loadCellAndCheck(engine,
+        this.loadCellAndCheckValue(engine,
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 BigInteger.valueOf(3+4));
     }
 
+    // deleteColumn....................................................................................................
+
+    @Test
+    public void testDeleteColumnZero() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference reference = this.cellReference(99, 0); // A3
+
+        cellStore.save(this.cell(reference, "99+0"));
+
+        engine.deleteColumns(reference.column(), 0);
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                reference,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99));
+    }
+
+    @Test
+    public void testDeleteColumn() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // A3
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        engine.deleteColumns(b.column(), 1);
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testDeleteColumn2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2 replaced by c
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // A3 DELETED
+        final SpreadsheetCellReference d = this.cellReference(99, 1); // B99 moved
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+        cellStore.save(this.cell(d, "7+8"));
+
+        final int count = 1;
+        engine.deleteColumns(b.column(), count); // $b delete, $c,$d columns -1.
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "7+8",
+                BigInteger.valueOf(7 + 8));
+    }
+
+    @Test
+    public void testDeleteColumnWithLabels() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2 replaced by c
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // A3 DELETED
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // B8 moved
+        final SpreadsheetCellReference e = this.cellReference(14, 9); // C9 moved LABEL=
+
+        cellStore.save(this.cell(a, "1+" + LABEL));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+" + LABEL));
+        cellStore.save(this.cell(e, "99+0")); // LABEL=
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, e));
+
+        final int count = 1;
+        engine.deleteColumns(b.column(), count); // $b delete, $c,$d columns -1.
+
+        this.loadLabelAndCheck(labelStore, LABEL, e.add(-count, 0));
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + LABEL,
+                BigInteger.valueOf(1 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+" + LABEL,
+                BigInteger.valueOf(4 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99 + 0));
+    }
+
+    @Test
+    public void testDeleteColumnWithLabelToDeletedCell() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+
+        cellStore.save(this.cell(a, "1+0"));
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, b));
+
+        final int count = 1;
+        engine.deleteColumns(b.column(), count); // $b delete, $c,$d columns -1.
+
+        this.loadLabelFailCheck(labelStore, LABEL);
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0",
+                BigInteger.valueOf(1 + 0));
+    }
+
+    @Test
+    public void testDeleteColumnWithReferences() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+        final SpreadsheetCellReference c = this.cellReference(10, 0); // A10 deleted
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // H13 moved
+        final SpreadsheetCellReference e = this.cellReference(14, 9); // I14 moved
+
+        cellStore.save(this.cell(a, "1+" + d));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5+" + b)); // =5+2
+
+        final int count = 1;
+        engine.deleteColumns(c.column(), count); // $c delete
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + d.add(-count, 0),
+                BigInteger.valueOf(1 + 4)); // reference should have been fixed.
+
+        this.loadCellAndCheckValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(2));
+
+        this.loadCellAndCheckValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+" + b,
+                BigInteger.valueOf(5 + 2));
+    }
+
+    @Test
+    public void testDeleteColumnWithReferences2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+        final SpreadsheetCellReference c = this.cellReference(10, 0); // A10 deleted
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // H13 moved
+        final SpreadsheetCellReference e = this.cellReference(14, 9); // I14 moved
+
+        cellStore.save(this.cell(a, "1+" + d));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5+" + b)); // =5+2
+
+        final int count = 2;
+        engine.deleteColumns(c.column(), count); // $c delete
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + d.add(-count, 0),
+                BigInteger.valueOf(1 + 4)); // reference should have been fixed.
+
+        this.loadCellAndCheckValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(2));
+
+        this.loadCellAndCheckValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+" + b,
+                BigInteger.valueOf(5 + 2));
+    }
+
+    @Test
+    public void testDeleteColumnWithReferencesToDeletedCell() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+
+        cellStore.save(this.cell(a, "1+" + b));
+        cellStore.save(this.cell(b, "2"));
+
+        final int count = 1;
+        engine.deleteColumns(b.column(), count); // $c delete
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+InvalidCellReference(" + b + ")",
+                "Invalid cell reference " + b); // reference should have been fixed.
+    }
+
+    @Test
+    public void testDeleteColumnSeveral() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(10, 0); // A2 DELETED
+        final SpreadsheetCellReference c = this.cellReference(11, 0); // A3 DELETED
+        final SpreadsheetCellReference d = this.cellReference(12, 2); // C4
+        final SpreadsheetCellReference e = this.cellReference(20, 3); // T3
+        final SpreadsheetCellReference f = this.cellReference(21, 4); // U4
+
+        cellStore.save(this.cell(a, "1"));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5"));
+        cellStore.save(this.cell(f, "6"));
+
+        final int count = 5;
+        engine.deleteColumns(this.column(7), count); // $b & $c
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(1));
+
+        this.loadCellAndCheckValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(4));
+
+        this.loadCellAndCheckValue(engine,
+                e.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(5));
+
+        this.loadCellAndCheckValue(engine,
+                f.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(6));
+    }
+
+    // deleteRow....................................................................................................
+
+    @Test
+    public void testDeleteRowZero() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference reference = this.cellReference(0, 1); // A2
+
+        cellStore.save(this.cell(reference, "99+0"));
+
+        engine.deleteRows(reference.row(), 0);
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                reference,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99));
+    }
+
+    @Test
+    public void testDeleteRow() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // C1
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        engine.deleteRows(b.row(), 1);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testDeleteRow2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); //
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // replaced by c
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // DELETED
+        final SpreadsheetCellReference d = this.cellReference(1, 9); // moved
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+        cellStore.save(this.cell(d, "7+8"));
+
+        final int count = 1;
+        engine.deleteRows(b.row(), count); // $b delete
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "7+8",
+                BigInteger.valueOf(7 + 8));
+    }
+
+    @Test
+    public void testDeleteRowWithLabels() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1 replaced by c
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // C1 DELETED
+        final SpreadsheetCellReference d = this.cellReference(8, 13); // I13 moved
+        final SpreadsheetCellReference e = this.cellReference(9, 14); // J14 moved LABEL=
+
+        cellStore.save(this.cell(a, "1+" + LABEL));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+" + LABEL));
+        cellStore.save(this.cell(e, "99+0")); // LABEL=
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, e));
+
+        final int count = 1;
+        engine.deleteRows(b.row(), count); // $b delete, $c,$d columns -1.
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadLabelAndCheck(labelStore, LABEL, e.add(0, -count));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + LABEL,
+                BigInteger.valueOf(1 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+" + LABEL,
+                BigInteger.valueOf(4 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99 + 0));
+    }
+
+    @Test
+    public void testDeleteRowWithLabelToDeletedCell() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+
+        cellStore.save(this.cell(a, "1+0"));
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, b));
+
+        final int count = 1;
+        engine.deleteRows(b.row(), count); // $b delete
+
+        this.loadLabelFailCheck(labelStore, LABEL);
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0",
+                BigInteger.valueOf(1 + 0));
+    }
+
+    @Test
+    public void testDeleteRowWithReferences() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+        final SpreadsheetCellReference c = this.cellReference(0, 10); // A10 deleted
+        final SpreadsheetCellReference d = this.cellReference(8, 13); // H13 moved
+        final SpreadsheetCellReference e = this.cellReference(9, 14); // I14 moved
+
+        cellStore.save(this.cell(a, "1+" + d));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5+" + b)); // =5+2
+
+        final int count = 1;
+        engine.deleteRows(c.row(), count); // $c delete
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + d.add(0, -count),
+                BigInteger.valueOf(1 + 4)); // reference should have been fixed.
+
+        this.loadCellAndCheckValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(2));
+
+        this.loadCellAndCheckValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+" + b,
+                BigInteger.valueOf(5 + 2));
+    }
+
+    @Test
+    public void testDeleteRowWithReferences2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+        final SpreadsheetCellReference c = this.cellReference(0, 10); // J1 deleted
+        final SpreadsheetCellReference d = this.cellReference(8, 13); // M8 moved
+        final SpreadsheetCellReference e = this.cellReference(9, 14); // N9 moved
+
+        cellStore.save(this.cell(a, "1+" + d));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5+" + b)); // =5+2
+
+        final int count = 2;
+        engine.deleteRows(c.row(), count); // $c delete
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + d.add(0, -count),
+                BigInteger.valueOf(1 + 4)); // reference should have been fixed.
+
+        this.loadCellAndCheckValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(2));
+
+        this.loadCellAndCheckValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+" + b,
+                BigInteger.valueOf(5 + 2));
+    }
+
+    @Test
+    public void testDeleteRowWithReferencesToDeletedCell() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+
+        cellStore.save(this.cell(a, "1+" + b));
+        cellStore.save(this.cell(b, "2"));
+
+        final int count = 1;
+        engine.deleteRows(b.row(), count); // $c delete
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+InvalidCellReference(" + b + ")",
+                "Invalid cell reference " + b); // reference should have been fixed.;
+    }
+
+    @Test
+    public void testDeleteRowSeveral() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 10); // H1 DELETED
+        final SpreadsheetCellReference c = this.cellReference(0, 11); // I1 DELETED
+        final SpreadsheetCellReference d = this.cellReference(2, 12); // L3
+        final SpreadsheetCellReference e = this.cellReference(3, 20); // T4
+        final SpreadsheetCellReference f = this.cellReference(4, 21); // U5
+
+        cellStore.save(this.cell(a, "1"));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5"));
+        cellStore.save(this.cell(f, "6"));
+
+        final int count = 5;
+        engine.deleteRows(this.row(7), count); // $b & $c
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(1));
+
+        this.loadCellAndCheckValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(4));
+
+        this.loadCellAndCheckValue(engine,
+                e.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(5));
+
+        this.loadCellAndCheckValue(engine,
+                f.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                BigInteger.valueOf(6));
+    }
+
+    // insertColumn....................................................................................................
+
+    @Test
+    public void testInsertColumnZero() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference reference = this.cellReference(99, 0); // A3
+
+        cellStore.save(this.cell(reference, "99+0"));
+
+        engine.insertColumns(reference.column(), 0);
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                reference,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99));
+    }
+
+    @Test
+    public void testInsertColumn() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // A3
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        final int count = 1;
+        engine.insertColumns(b.column(), count);
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+4",
+                BigInteger.valueOf(3 + 4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testInsertColumn2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2 MOVED
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // A3 MOVED
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        final int count = 1;
+        engine.insertColumns(b.column(), count); // $b insert, $c,$d columns -1.
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+4",
+                BigInteger.valueOf(3 + 4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testInsertColumnWithLabels() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2 moved
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // A3 MOVED
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // B8 moved
+
+        cellStore.save(this.cell(a, "1+" + LABEL));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0+" + LABEL));
+        cellStore.save(this.cell(d, "99+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, d));
+
+        final int count = 1;
+        engine.insertColumns(b.column(), count); // $b insert
+
+        this.loadLabelAndCheck(labelStore, LABEL, d.add(+count, 0));
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + LABEL,
+                BigInteger.valueOf(1 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0+" + LABEL,
+                BigInteger.valueOf(3 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99 + 0));
+    }
+
+    @Test
+    public void testInsertColumnWithReferences() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+        final SpreadsheetCellReference c = this.cellReference(10, 0); // A10 moved
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // H13 moved
+
+        cellStore.save(this.cell(a, "1+0+" + d));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+0+" + b));
+
+        final int count = 1;
+        engine.insertColumns(c.column(), count); // $c insert
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0+" + d.add(+count, 0),
+                BigInteger.valueOf(1 + 0 + 4 + 2)); // reference should have been fixed.
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+0+" + b,
+                BigInteger.valueOf(4 + 2));
+    }
+
+    @Test
+    public void testInsertColumnWithReferences2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // A2
+        final SpreadsheetCellReference c = this.cellReference(10, 0); // A10 moved
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // H13 moved
+
+        cellStore.save(this.cell(a, "1+0+" + d));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+0+" + b)); // =5+2
+
+        final int count = 2;
+        engine.insertColumns(c.column(), count); // $c insert
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0+" + d.add(+count, 0),
+                BigInteger.valueOf(1 + 0 + 4 + 2)); // reference should have been fixed.
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+0+" + b,
+                BigInteger.valueOf(4 + 0 + 2));
+    }
+
+    @Test
+    public void testInsertColumnSeveral() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(10, 0); // A2 MOVED
+        final SpreadsheetCellReference c = this.cellReference(11, 0); // A3 MOVED
+        final SpreadsheetCellReference d = this.cellReference(12, 2); // C4 MOVED
+        final SpreadsheetCellReference e = this.cellReference(20, 3); // T3 MOVED
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+0"));
+        cellStore.save(this.cell(e, "5+0"));
+
+        final int count = 5;
+        engine.insertColumns(this.column(7), count); // $b & $c
+
+        this.countAndCheck(cellStore, 5);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0",
+                BigInteger.valueOf(1 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+0",
+                BigInteger.valueOf(4 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(+count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+0",
+                BigInteger.valueOf(5 + 0));
+    }
+
+    // insertRow....................................................................................................
+
+    @Test
+    public void testInsertRowZero() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference reference = this.cellReference(0, 99); // A3
+
+        cellStore.save(this.cell(reference, "99+0"));
+
+        engine.insertRows(reference.row(), 0);
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                reference,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99));
+    }
+
+    @Test
+    public void testInsertRow() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // A2
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // A3
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        final int count = 1;
+        engine.insertRows(b.row(), count);
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+4",
+                BigInteger.valueOf(3 + 4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testInsertRow2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // A2 MOVED
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // A3 MOVED
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        final int count = 1;
+        engine.insertRows(b.row(), count); // $b insert
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+2",
+                BigInteger.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+4",
+                BigInteger.valueOf(3 + 4));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+6",
+                BigInteger.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testInsertRowWithLabels() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // A2 moved
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // A3 MOVED
+        final SpreadsheetCellReference d = this.cellReference(8, 13); // B8 moved
+
+        cellStore.save(this.cell(a, "1+" + LABEL));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0+" + LABEL));
+        cellStore.save(this.cell(d, "99+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, d));
+
+        final int count = 1;
+        engine.insertRows(b.row(), count); // $b insert
+
+        this.loadLabelAndCheck(labelStore, LABEL, d.add(0, +count));
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+" + LABEL,
+                BigInteger.valueOf(1 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0+" + LABEL,
+                BigInteger.valueOf(3 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "99+0",
+                BigInteger.valueOf(99 + 0));
+    }
+
+    @Test
+    public void testInsertRowWithReferences() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // A2
+        final SpreadsheetCellReference c = this.cellReference(0, 10); // A10 moved
+        final SpreadsheetCellReference d = this.cellReference(8, 13); // H13 moved
+
+        cellStore.save(this.cell(a, "1+0+" + d));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+0+" + b));
+
+        final int count = 1;
+        engine.insertRows(c.row(), count); // $c insert
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0+" + d.add(0, +count),
+                BigInteger.valueOf(1 + 0 + 4 + 2)); // reference should have been fixed.
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+0+" + b,
+                BigInteger.valueOf(4 + 2));
+    }
+
+    @Test
+    public void testInsertRowWithReferences2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // A2
+        final SpreadsheetCellReference c = this.cellReference(0, 10); // A10 moved
+        final SpreadsheetCellReference d = this.cellReference(8, 13); // H13 moved
+
+        cellStore.save(this.cell(a, "1+0+" + d));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+0+" + b)); // =5+2
+
+        final int count = 2;
+        engine.insertRows(c.row(), count); // $c insert
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0+" + d.add(0, +count),
+                BigInteger.valueOf(1 + 0 + 4 + 2)); // reference should have been fixed.
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+0+" + b,
+                BigInteger.valueOf(4 + 0 + 2));
+    }
+
+    @Test
+    public void testInsertRowSeveral() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 10); // A2 MOVED
+        final SpreadsheetCellReference c = this.cellReference(0, 11); // A3 MOVED
+        final SpreadsheetCellReference d = this.cellReference(2, 12); // C4 MOVED
+        final SpreadsheetCellReference e = this.cellReference(3, 20); // T3 MOVED
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(b, "2+0"));
+        cellStore.save(this.cell(c, "3+0"));
+        cellStore.save(this.cell(d, "4+0"));
+        cellStore.save(this.cell(e, "5+0"));
+
+        final int count = 5;
+        engine.insertRows(this.row(7), count); // $b & $c
+
+        this.countAndCheck(cellStore, 5);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "1+0",
+                BigInteger.valueOf(1 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "2+0",
+                BigInteger.valueOf(2 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "3+0",
+                BigInteger.valueOf(3 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "4+0",
+                BigInteger.valueOf(4 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                "5+0",
+                BigInteger.valueOf(5 + 0));
+    }
+
+    //  helpers.......................................................................................................
+    
     @Override
     BasicSpreadsheetEngine createSpreadsheetEngine() {
         return this.createSpreadsheetEngine(this.cellStore());
@@ -272,7 +1538,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
     private BasicSpreadsheetEngine createSpreadsheetEngine(final SpreadsheetCellStore cellStore,
                                                            final SpreadsheetLabelStore labelStore) {
-        return BasicSpreadsheetEngine.with(this.id(), cellStore, this.parser(), this.parserContext(), this.evaluationContextFactory(labelStore));
+        return BasicSpreadsheetEngine.with(this.id(), cellStore, labelStore, this.parser(), this.parserContext(), this.evaluationContextFactory(labelStore));
     }
 
     private SpreadsheetId id() {
@@ -304,7 +1570,12 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     private Function<SpreadsheetEngine, ExpressionEvaluationContext> evaluationContextFactory(final SpreadsheetLabelStore labelStore) {
-        final BiFunction<ExpressionNodeName, List<Object>, Object> functions = (name, params) -> {throw new UnsupportedOperationException();};
+        final BiFunction<ExpressionNodeName, List<Object>, Object> functions = (name, params) -> {
+            if(name.value().equals(SpreadsheetFormula.INVALID_CELL_REFERENCE.value())) {
+                throw new ExpressionEvaluationException("Invalid cell reference " + params.get(0).toString());
+            }
+            throw new UnsupportedOperationException(name+ "(" + params.stream().map(p->p.toString()).collect(Collectors.joining(",")) + ")");
+        };
 
         return SpreadsheetEngines.spreadsheetEngineExpressionEvaluationContextFunction(
                 functions,
@@ -314,8 +1585,20 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         );
     }
 
+    private SpreadsheetColumnReference column(final int column) {
+        return SpreadsheetReferenceKind.ABSOLUTE.column(column);
+    }
+
+    private SpreadsheetRowReference row(final int row) {
+        return SpreadsheetReferenceKind.ABSOLUTE.row(row);
+    }
+
     private SpreadsheetCellReference cellReference(final int column, final int row) {
-        return SpreadsheetCellReference.with(SpreadsheetReferenceKind.ABSOLUTE.column(column), SpreadsheetReferenceKind.ABSOLUTE.row(row));
+        return SpreadsheetReferenceKind.ABSOLUTE.column(column).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(row));
+    }
+
+    private SpreadsheetCell cell(final SpreadsheetCellReference reference, final String formula) {
+        return SpreadsheetCell.with(reference, SpreadsheetFormula.with(formula));
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTestCase.java
@@ -3,11 +3,17 @@ package walkingkooka.spreadsheet.engine;
 import org.junit.Test;
 import walkingkooka.spreadsheet.SpreadsheetCell;
 import walkingkooka.spreadsheet.SpreadsheetError;
+import walkingkooka.spreadsheet.SpreadsheetFormula;
+import walkingkooka.spreadsheet.SpreadsheetLabelMapping;
+import walkingkooka.spreadsheet.store.Store;
+import walkingkooka.spreadsheet.store.label.SpreadsheetLabelStore;
 import walkingkooka.test.PackagePrivateClassTestCase;
 import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetReferenceKind;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
 
 import java.util.Optional;
 
@@ -18,8 +24,10 @@ import static org.junit.Assert.fail;
 
 public abstract class SpreadsheetEngineTestCase<E extends SpreadsheetEngine> extends PackagePrivateClassTestCase<E> {
 
-    final static SpreadsheetCellReference REFERENCE = SpreadsheetReferenceKind.ABSOLUTE.column(1).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(2));
-    final static SpreadsheetLabelName LABEL = SpreadsheetLabelName.with("label123");
+    final static SpreadsheetColumnReference COLUMN = SpreadsheetReferenceKind.ABSOLUTE.column(1);
+    final static SpreadsheetRowReference ROW = SpreadsheetReferenceKind.ABSOLUTE.row(2);
+    final static SpreadsheetCellReference REFERENCE = COLUMN.setRow(ROW);
+    final static SpreadsheetLabelName LABEL = SpreadsheetLabelName.with("LABEL123");
 
     @Test(expected = NullPointerException.class)
     public final void testLoadCellNullCellFails() {
@@ -32,6 +40,46 @@ public abstract class SpreadsheetEngineTestCase<E extends SpreadsheetEngine> ext
                 null);
     }
 
+    @Test(expected = NullPointerException.class)
+    public final void testDeleteColumnsNullColumnFails() {
+        this.createSpreadsheetEngine().deleteColumns(null, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testDeleteColumnsNegativeCountFails() {
+        this.createSpreadsheetEngine().deleteColumns(COLUMN, -1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testDeleteRowsNullRowFails() {
+        this.createSpreadsheetEngine().deleteRows(null, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testDeleteRowsNegativeCountFails() {
+        this.createSpreadsheetEngine().deleteRows(ROW, -1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testInsertColumnsNullColumnFails() {
+        this.createSpreadsheetEngine().insertColumns(null, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testInsertColumnsNegativeCountFails() {
+        this.createSpreadsheetEngine().insertColumns(COLUMN, -1);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public final void testInsertRowsNullRowFails() {
+        this.createSpreadsheetEngine().insertRows(null, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public final void testInsertRowsNegativeCountFails() {
+        this.createSpreadsheetEngine().insertRows(ROW, -1);
+    }
+    
     abstract E createSpreadsheetEngine();
 
     final SpreadsheetCell loadCellOrFail(final SpreadsheetEngine engine,
@@ -50,6 +98,11 @@ public abstract class SpreadsheetEngineTestCase<E extends SpreadsheetEngine> ext
     }
 
     final void loadCellFailCheck(final SpreadsheetEngine engine,
+                                 final SpreadsheetCellReference reference) {
+        this.loadCellFailCheck(engine, reference, SpreadsheetEngineLoading.SKIP_EVALUATE);
+    }
+
+    final void loadCellFailCheck(final SpreadsheetEngine engine,
                                  final SpreadsheetCellReference reference,
                                  final SpreadsheetEngineLoading loading) {
         final Optional<SpreadsheetCell> cell = engine.loadCell(reference, loading);
@@ -65,12 +118,40 @@ public abstract class SpreadsheetEngineTestCase<E extends SpreadsheetEngine> ext
                 this.valueOrError(cell, null));
     }
 
-    final void loadCellAndCheck(final SpreadsheetEngine engine,
-                                final SpreadsheetCellReference reference,
-                                final SpreadsheetEngineLoading loading,
-                                final Object value) {
+    final void loadCellAndCheckFormula(final SpreadsheetEngine engine,
+                                     final SpreadsheetCellReference reference,
+                                     final SpreadsheetEngineLoading loading,
+                                     final String formula) {
         final SpreadsheetCell cell = this.loadCellOrFail(engine, reference, loading);
-        assertEquals("values from returned cells=" + cell,
+        this.checkFormula(cell, formula);
+    }
+
+    final void loadCellAndCheckFormulaAndValue(final SpreadsheetEngine engine,
+                                       final SpreadsheetCellReference reference,
+                                       final SpreadsheetEngineLoading loading,
+                                       final String formula,
+                                       final Object value) {
+        final SpreadsheetCell cell = this.loadCellOrFail(engine, reference, loading);
+        this.checkFormula(cell, formula);
+        this.checkValueOrError(cell, value);
+    }
+
+    final void loadCellAndCheckValue(final SpreadsheetEngine engine,
+                                     final SpreadsheetCellReference reference,
+                                     final SpreadsheetEngineLoading loading,
+                                     final Object value) {
+        final SpreadsheetCell cell = this.loadCellOrFail(engine, reference, loading);
+        this.checkValueOrError(cell, value);
+    }
+
+    private void checkFormula(final SpreadsheetCell cell, final String formula) {
+        assertEquals("formula from returned cell=" + cell,
+                SpreadsheetFormula.with(formula),
+                cell.formula());
+    }
+
+    private void checkValueOrError(final SpreadsheetCell cell, final Object value) {
+        assertEquals("values from returned cell=" + cell,
                 value,
                 this.valueOrError(cell, "Value and Error absent (" + cell + ")"));
     }
@@ -92,5 +173,20 @@ public abstract class SpreadsheetEngineTestCase<E extends SpreadsheetEngine> ext
         final Optional<SpreadsheetError> error = cell.error();
         assertNotEquals("Expected error missing=" + cell, SpreadsheetCell.NO_ERROR, error);
         assertTrue("Error message " + error + " missing " + CharSequences.quoteAndEscape(errorContains), error.get().value().contains(errorContains));
+    }
+
+    final void loadLabelAndCheck(final SpreadsheetLabelStore labelStore,
+                                 final SpreadsheetLabelName label,
+                                 final SpreadsheetCellReference reference) {
+        assertEquals("label loaded", Optional.of(SpreadsheetLabelMapping.with(label, reference)), labelStore.load(label));
+    }
+
+    final void loadLabelFailCheck(final SpreadsheetLabelStore labelStore,
+                                 final SpreadsheetLabelName label) {
+        assertEquals("label loaded failed", Optional.empty(), labelStore.load(label));
+    }
+
+    final void countAndCheck(final Store<?, ?> store, final int count) {
+        assertEquals("record count in " + store, count, store.count());
     }
 }


### PR DESCRIPTION
- Added constant to SpreadsheetFormula.INVALID_CELL_REFERENCE which replaces
  invalid cell references due to a deleted column/row within expressions.
- Added SpreadsheetFormula.setValue
- Cells with invalid cell refences due to a deleted col/row are replaced
with "InvalidCellReference("cell-reference-literal").