### PR TITLE
https://github.com/mP1/walkingkooka/pull/430

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/datavalidation/BasicSpreadsheetDataValidatorContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/datavalidation/BasicSpreadsheetDataValidatorContext.java
@@ -8,6 +8,7 @@ import walkingkooka.tree.expression.ExpressionReference;
 import java.math.MathContext;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A {@link SpreadsheetDataValidatorContext} which wraps a {@link ExpressionEvaluationContext}.
@@ -36,7 +37,7 @@ final class BasicSpreadsheetDataValidatorContext implements SpreadsheetDataValid
                                                  final ExpressionEvaluationContext context) {
         super();
         this.cellReference = cellReference;
-        this.value = ExpressionNode.valueOrFail(value);
+        this.value = Optional.of(ExpressionNode.valueOrFail(value));
         this.context = context;
     }
 
@@ -88,13 +89,13 @@ final class BasicSpreadsheetDataValidatorContext implements SpreadsheetDataValid
     }
 
     @Override
-    public ExpressionNode reference(final ExpressionReference reference) {
+    public Optional<ExpressionNode> reference(final ExpressionReference reference) {
         return this.cellReference().equals(reference) ?
                 this.value :
                 this.context.reference(reference);
     }
 
-    private final ExpressionNode value;
+    private final Optional<ExpressionNode> value;
 
     @Override
     public MathContext mathContext() {

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
  * A {@link Function} which may be passed to {@link walkingkooka.tree.expression.ExpressionEvaluationContexts#basic(BiFunction, Function, MathContext, Converter, walkingkooka.DecimalNumberContext)}
  * and acts as a bridge resolving references to a {@link SpreadsheetEngine}.
  */
-final class SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction implements Function<ExpressionReference, ExpressionNode> {
+final class SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction implements Function<ExpressionReference, Optional<ExpressionNode>> {
 
     /**
      * Factory that creates a new {@link SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction}
@@ -49,7 +49,7 @@ final class SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpre
     }
 
     @Override
-    public ExpressionNode apply(final ExpressionReference reference) {
+    public Optional<ExpressionNode> apply(final ExpressionReference reference) {
         Objects.requireNonNull(reference, "reference");
 
         SpreadsheetCellReference cellReference = null;
@@ -75,11 +75,7 @@ final class SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpre
             throw new ExpressionEvaluationException(error.get().value());
         }
 
-        final Optional<ExpressionNode> expression = formula.expression();
-        if(!expression.isPresent()) {
-            throw new ExpressionEvaluationException("Unknown cell reference " + reference);
-        }
-        return expression.get();
+        return formula.expression();
     }
 
     private final SpreadsheetEngine engine;

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngines.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngines.java
@@ -7,6 +7,7 @@ import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.type.PublicStaticHelper;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 public final class SpreadsheetEngines implements PublicStaticHelper {
@@ -30,9 +31,9 @@ public final class SpreadsheetEngines implements PublicStaticHelper {
     /**
      * {@see SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction}
      */
-    public static Function<ExpressionReference, ExpressionNode> expressionEvaluationContextExpressionReferenceExpressionNodeFunction(final SpreadsheetEngine engine,
-                                                                                                                                     final SpreadsheetLabelStore labelStore,
-                                                                                                                                     final SpreadsheetEngineContext context) {
+    public static Function<ExpressionReference, Optional<ExpressionNode>> expressionEvaluationContextExpressionReferenceExpressionNodeFunction(final SpreadsheetEngine engine,
+                                                                                                                                               final SpreadsheetLabelStore labelStore,
+                                                                                                                                               final SpreadsheetEngineContext context) {
         return SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction.with(engine, labelStore, context);
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunctionTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunctionTest.java
@@ -7,9 +7,11 @@ import walkingkooka.tree.expression.ExpressionNode;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.util.FunctionTestCase;
 
+import java.util.Optional;
+
 public final class SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunctionTest extends FunctionTestCase<
         SpreadsheetEngineExpressionEvaluationContextExpressionReferenceExpressionNodeFunction,
-        ExpressionReference, ExpressionNode> {
+        ExpressionReference, Optional<ExpressionNode>> {
 
     @Test(expected = NullPointerException.class)
     public void testWithNullEngineFails() {


### PR DESCRIPTION
- Changes because of ExpressionEvaluationContext.reference signature change,
  now returns Optional<ExpressionNode> was ExpressionNode.