### PR TITLE
SpreadsheetLabelMapping to ExpressionReference(cell, range) previousl…

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetLabelMapping.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetLabelMapping.java
@@ -2,31 +2,31 @@ package walkingkooka.spreadsheet;
 
 import walkingkooka.Cast;
 import walkingkooka.test.HashCodeEqualsDefined;
-import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
+import walkingkooka.tree.expression.ExpressionReference;
 
 import java.util.Objects;
 
 /**
- * Holds a label to cell mapping.
+ * Holds a {@link SpreadsheetLabelName label} to {@link ExpressionReference} mapping.
  */
 public final class SpreadsheetLabelMapping implements HashCodeEqualsDefined {
 
     /**
      * Creates a new {@link SpreadsheetLabelMapping}
      */
-    public static SpreadsheetLabelMapping with(final SpreadsheetLabelName label, final SpreadsheetCellReference cell) {
+    public static SpreadsheetLabelMapping with(final SpreadsheetLabelName label, final ExpressionReference reference) {
         checkLabel(label);
-        checkCell(cell);
-        return new SpreadsheetLabelMapping(label, cell);
+        checkReference(reference);
+        return new SpreadsheetLabelMapping(label, reference);
     }
 
     /**
      * Private ctor use factory
      */
-    private SpreadsheetLabelMapping(final SpreadsheetLabelName label, final SpreadsheetCellReference cell) {
+    private SpreadsheetLabelMapping(final SpreadsheetLabelName label, final ExpressionReference reference) {
         this.label = label;
-        this.cell = cell;
+        this.reference = reference;
     }
 
     public SpreadsheetLabelName label() {
@@ -37,7 +37,7 @@ public final class SpreadsheetLabelMapping implements HashCodeEqualsDefined {
         checkLabel(label);
         return this.label.equals(label) ?
                this :
-               this.replace(label, cell);
+               this.replace(label, reference);
     }
     
     private static void checkLabel(final SpreadsheetLabelName label) {
@@ -46,32 +46,32 @@ public final class SpreadsheetLabelMapping implements HashCodeEqualsDefined {
     
     private final SpreadsheetLabelName label;
 
-    public SpreadsheetCellReference cell() {
-        return this.cell;
+    public ExpressionReference reference() {
+        return this.reference;
     }
 
-    public SpreadsheetLabelMapping setCell(final SpreadsheetCellReference cell) {
-        checkCell(cell);
-        return this.cell.equals(cell) ?
+    public SpreadsheetLabelMapping setReference(final ExpressionReference reference) {
+        checkReference(reference);
+        return this.reference.equals(reference) ?
                 this :
-                this.replace(this.label, cell);
+                this.replace(this.label, reference);
     }
     
-    private final SpreadsheetCellReference cell;
+    private final ExpressionReference reference;
 
-    private static void checkCell(final SpreadsheetCellReference cell) {
-        Objects.requireNonNull(cell, "cell");
+    private static void checkReference(final ExpressionReference reference) {
+        Objects.requireNonNull(reference, "reference");
     }
 
-    private SpreadsheetLabelMapping replace(final SpreadsheetLabelName label, final SpreadsheetCellReference cell) {
-        return new SpreadsheetLabelMapping(label, cell);
+    private SpreadsheetLabelMapping replace(final SpreadsheetLabelName label, final ExpressionReference reference) {
+        return new SpreadsheetLabelMapping(label, reference);
     }
 
     // HashCodeEqualsDefined..........................................................................................
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.label, this.cell);
+        return Objects.hash(this.label, this.reference);
     }
 
     @Override
@@ -83,11 +83,11 @@ public final class SpreadsheetLabelMapping implements HashCodeEqualsDefined {
 
     private boolean equals0(final SpreadsheetLabelMapping other) {
         return this.label.equals(other.label) &
-               this.cell.equals(other.cell);
+               this.reference.equals(other.reference);
     }
 
     @Override
     public String toString() {
-        return this.label + "=" + this.cell;
+        return this.label + "=" + this.reference;
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetRange.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetRange.java
@@ -7,6 +7,7 @@ import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetReferenceKind;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
+import walkingkooka.tree.expression.ExpressionReference;
 
 import java.util.List;
 import java.util.Objects;
@@ -14,9 +15,9 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
- * Holds a range.
+ * Holds a range. Note the begin component is always before the end, with rows being the significant axis before column.
  */
-public final class SpreadsheetRange implements HashCodeEqualsDefined {
+public final class SpreadsheetRange implements ExpressionReference, HashCodeEqualsDefined {
 
     /**
      * Computes the range of the given cells.

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteColumnOrRow.java
@@ -24,7 +24,7 @@ final class BasicSpreadsheetEngineDeleteColumnOrRow extends BasicSpreadsheetEngi
     private void delete0(final SpreadsheetEngineContext context) {
         this.columnOrRow.delete(this.columnOrRow.value, this.columnOrRow.count);
         this.move();
-        this.columnOrRow.fixAllExpressionCellReferences(context);
+        this.columnOrRow.fixAllExpressionReferences(context);
         this.columnOrRow.fixAllLabelMappings();
     }
 
@@ -59,6 +59,6 @@ final class BasicSpreadsheetEngineDeleteColumnOrRow extends BasicSpreadsheetEngi
 
     @Override
     void fixLabelMapping(final SpreadsheetLabelMapping mapping) {
-        this.columnOrRow.deleteFixReference(mapping);
+        this.columnOrRow.deleteOrFixLabelMapping(mapping);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn.java
@@ -78,4 +78,14 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowColumn extends BasicS
     int columnOrRowValue(final SpreadsheetCellReference cell) {
         return cell.column().value();
     }
+
+    @Override
+    SpreadsheetCellReference setColumnOrRowValue(final SpreadsheetCellReference cell, final int value) {
+        return cell.setColumn(cell.column().setValue(value));
+    }
+
+    @Override
+    SpreadsheetCellReference addColumnOrRowValue(final SpreadsheetCellReference cell, final int value) {
+        return cell.setColumn(cell.column().add(value));
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow.java
@@ -78,4 +78,14 @@ final class BasicSpreadsheetEngineDeleteOrInsertColumnOrRowRow extends BasicSpre
     final int columnOrRowValue(final SpreadsheetCellReference cell) {
         return cell.row().value();
     }
+
+    @Override
+    SpreadsheetCellReference setColumnOrRowValue(final SpreadsheetCellReference cell, final int value) {
+        return cell.setRow(cell.row().setValue(value));
+    }
+
+    @Override
+    SpreadsheetCellReference addColumnOrRowValue(final SpreadsheetCellReference cell, final int value) {
+        return cell.setRow(cell.row().add(value));
+    }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineInsertColumnOrRow.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineInsertColumnOrRow.java
@@ -23,7 +23,7 @@ final class BasicSpreadsheetEngineInsertColumnOrRow extends BasicSpreadsheetEngi
      */
     private void insert0(final SpreadsheetEngineContext context) {
         this.move();
-        this.columnOrRow.fixAllExpressionCellReferences(context);
+        this.columnOrRow.fixAllExpressionReferences(context);
         this.columnOrRow.fixAllLabelMappings();
     }
 
@@ -54,6 +54,6 @@ final class BasicSpreadsheetEngineInsertColumnOrRow extends BasicSpreadsheetEngi
 
     @Override
     void fixLabelMapping(final SpreadsheetLabelMapping mapping) {
-        this.columnOrRow.insertFixReference(mapping);
+        this.columnOrRow.insertFixLabelMapping(mapping);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTestCase.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/SpreadsheetEngineTestCase.java
@@ -16,6 +16,7 @@ import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetColumnReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetReferenceKind;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetRowReference;
+import walkingkooka.tree.expression.ExpressionReference;
 
 import java.util.Optional;
 
@@ -217,7 +218,7 @@ public abstract class SpreadsheetEngineTestCase<E extends SpreadsheetEngine> ext
 
     protected final void loadLabelAndCheck(final SpreadsheetLabelStore labelStore,
                                            final SpreadsheetLabelName label,
-                                           final SpreadsheetCellReference reference) {
+                                           final ExpressionReference reference) {
         assertEquals("label loaded", Optional.of(SpreadsheetLabelMapping.with(label, reference)), labelStore.load(label));
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetLabelMappingTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetLabelMappingTest.java
@@ -2,9 +2,9 @@ package walkingkooka.spreadsheet;
 
 import org.junit.Test;
 import walkingkooka.test.PublicClassTestCase;
-import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetLabelName;
 import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetReferenceKind;
+import walkingkooka.tree.expression.ExpressionReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -14,15 +14,15 @@ import static org.junit.Assert.assertSame;
 public final class SpreadsheetLabelMappingTest extends PublicClassTestCase<SpreadsheetLabelMapping> {
 
     private final static SpreadsheetLabelName LABEL =SpreadsheetLabelName.with("label");
-    private final static SpreadsheetCellReference CELL = cell(1);
+    private final static ExpressionReference REFERENCE = cell(1);
 
     @Test(expected = NullPointerException.class)
     public void testWithNullLabelFails() {
-        SpreadsheetLabelMapping.with(null, CELL);
+        SpreadsheetLabelMapping.with(null, REFERENCE);
     }
 
     @Test(expected = NullPointerException.class)
-    public void testWithNullCellFails() {
+    public void testWithNullReferenceFails() {
         SpreadsheetLabelMapping.with(LABEL, null);
     }
 
@@ -30,7 +30,7 @@ public final class SpreadsheetLabelMappingTest extends PublicClassTestCase<Sprea
     public void testWith() {
         final SpreadsheetLabelMapping mapping = this.createMapping();
         this.checkLabel(mapping, LABEL);
-        this.checkCell(mapping, CELL);
+        this.checkReference(mapping, REFERENCE);
     }
     
     // setLabel.......................................................................................................
@@ -54,53 +54,53 @@ public final class SpreadsheetLabelMappingTest extends PublicClassTestCase<Sprea
 
         assertNotSame(mapping, different);
         this.checkLabel(different, differentLabel);
-        this.checkCell(different, CELL);
+        this.checkReference(different, REFERENCE);
     }
 
-    // setCell.......................................................................................................
+    // setReference.......................................................................................................
 
     @Test(expected = NullPointerException.class)
-    public void testSetCellNullFails() {
-        this.createMapping().setCell(null);
+    public void testSetReferenceNullFails() {
+        this.createMapping().setReference(null);
     }
 
     @Test
-    public void testSetCellSame() {
+    public void testSetReferenceSame() {
         final SpreadsheetLabelMapping mapping = this.createMapping();
-        assertSame(mapping, mapping.setCell(CELL));
+        assertSame(mapping, mapping.setReference(REFERENCE));
     }
 
     @Test
-    public void testSetCellDifferent() {
+    public void testSetReferenceDifferent() {
         final SpreadsheetLabelMapping mapping = this.createMapping();
-        final SpreadsheetCellReference differentCell = cell(999);
-        final SpreadsheetLabelMapping different = mapping.setCell(differentCell);
+        final ExpressionReference differentReference = cell(999);
+        final SpreadsheetLabelMapping different = mapping.setReference(differentReference);
 
         assertNotSame(mapping, different);
         this.checkLabel(different, LABEL);
-        this.checkCell(different, differentCell);
+        this.checkReference(different, differentReference);
     }
 
     // toString...............................................................................................
 
     @Test
     public void testToString() {
-        assertEquals(LABEL + "=" + CELL, this.createMapping().toString());
+        assertEquals(LABEL + "=" + REFERENCE, this.createMapping().toString());
     }
 
     private SpreadsheetLabelMapping createMapping() {
-        return SpreadsheetLabelMapping.with(LABEL, CELL);
+        return SpreadsheetLabelMapping.with(LABEL, REFERENCE);
     }
 
     private void checkLabel(final SpreadsheetLabelMapping mapping, final SpreadsheetLabelName label) {
         assertEquals("label", label, mapping.label());
     }
     
-    private void checkCell(final SpreadsheetLabelMapping mapping, final SpreadsheetCellReference cell) {
-        assertEquals("cell", cell, mapping.cell());
+    private void checkReference(final SpreadsheetLabelMapping mapping, final ExpressionReference reference) {
+        assertEquals("reference", reference, mapping.reference());
     }
 
-    private static SpreadsheetCellReference cell(final int column) {
+    private static ExpressionReference cell(final int column) {
         return SpreadsheetReferenceKind.ABSOLUTE.column(column)
                 .setRow(SpreadsheetReferenceKind.RELATIVE.row(2));
     }

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -234,19 +234,19 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(1+2),
+                BigDecimal.valueOf(1 + 2),
                 DEFAULT_SUFFIX);
         this.loadCellAndCheckFormatted2(engine,
                 b,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(3+4),
+                BigDecimal.valueOf(3 + 4),
                 DEFAULT_SUFFIX);
         this.loadCellAndCheckFormatted2(engine,
                 c,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(5+6),
+                BigDecimal.valueOf(5 + 6),
                 DEFAULT_SUFFIX);
     }
 
@@ -300,7 +300,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 b,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(3+4),
+                BigDecimal.valueOf(3 + 4),
                 DEFAULT_SUFFIX);
 
         // reference to B1 which has formula
@@ -308,7 +308,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(3+4),
+                BigDecimal.valueOf(3 + 4),
                 DEFAULT_SUFFIX);
     }
 
@@ -332,7 +332,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 b,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(3+4),
+                BigDecimal.valueOf(3 + 4),
                 DEFAULT_SUFFIX);
 
         // reference to B1 which has formula
@@ -340,7 +340,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(3+4),
+                BigDecimal.valueOf(3 + 4),
                 DEFAULT_SUFFIX);
     }
 
@@ -351,7 +351,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
-        final SpreadsheetEngineContext context = this.createContext(labelStore,  engine);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
 
         final SpreadsheetCellReference reference = this.cellReference(99, 0); // A3
 
@@ -445,7 +445,44 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteColumnWithLabels() {
+    public void testDeleteColumnWithLabelsToCellReferenceIgnored() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(5, 1); // E2
+
+        cellStore.save(this.cell(a, "99+0"));
+        cellStore.save(this.cell(b, "2+0+" + LABEL));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a));
+
+        final int count = 1;
+        engine.deleteColumns(b.column().add(-1), count, context); // delete column before $b
+
+        this.loadLabelAndCheck(labelStore, LABEL, a);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(-1, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+0+" + LABEL,
+                BigDecimal.valueOf(2 + 99));
+    }
+
+    @Test
+    public void testDeleteColumnWithLabelsToCellReferencedFixed() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -530,7 +567,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteColumnWithReferences() {
+    public void testDeleteColumnWithCellReferences() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -583,7 +620,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteColumnWithReferences2() {
+    public void testDeleteColumnWithCellReferences2() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -636,7 +673,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteColumnWithReferencesToDeletedCell() {
+    public void testDeleteColumnWithCellReferencesToDeletedCell() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -719,7 +756,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     // deleteRow....................................................................................................
 
     @Test
-    public void testDeleteRowsZero() {
+    public void testDeleteRowsNone() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -742,7 +779,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteRows() {
+    public void testDeleteRowsOne() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -776,7 +813,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteRows2() {
+    public void testDeleteRowsOne2() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -820,64 +857,46 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteRowsWithLabels() {
+    public void testDeleteRowsMany() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
         final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
 
-        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
-        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1 replaced by c
-        final SpreadsheetCellReference c = this.cellReference(0, 2); // C1 DELETED
-        final SpreadsheetCellReference d = this.cellReference(8, 13); // I13 moved
-        final SpreadsheetCellReference e = this.cellReference(9, 14); // J14 moved LABEL=
+        final SpreadsheetCellReference a = this.cellReference(0, 0); //
+        final SpreadsheetCellReference b = this.cellReference(0, 1); // replaced by c
+        final SpreadsheetCellReference c = this.cellReference(0, 2); // DELETED
+        final SpreadsheetCellReference d = this.cellReference(1, 9); // moved
 
-        cellStore.save(this.cell(a, "1+" + LABEL));
-        cellStore.save(this.cell(b, "2+0"));
-        cellStore.save(this.cell(c, "3+0"));
-        cellStore.save(this.cell(d, "4+" + LABEL));
-        cellStore.save(this.cell(e, "99+0")); // LABEL=
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+        cellStore.save(this.cell(d, "7+8"));
 
-        labelStore.save(SpreadsheetLabelMapping.with(LABEL, e));
+        final int count = 2;
+        engine.deleteRows(b.row(), count, context); // $b, $c deleted
 
-        final int count = 1;
-        engine.deleteRows(b.row(), count, context); // $b delete, $c,$d columns -1.
-
-        this.countAndCheck(cellStore, 4);
-
-        this.loadLabelAndCheck(labelStore, LABEL, e.add(0, -count));
+        this.countAndCheck(cellStore, 2);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                "1+" + LABEL,
-                BigDecimal.valueOf(1 + 99));
-
-        this.loadCellAndCheckFormulaAndValue(engine,
-                b,
-                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
-                context,
-                "3+0",
-                BigDecimal.valueOf(3));
+                "1+2",
+                BigDecimal.valueOf(1 + 2));
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d.add(0, -count),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                "4+" + LABEL,
-                BigDecimal.valueOf(4 + 99));
-
-        this.loadCellAndCheckFormulaAndValue(engine,
-                e.add(0, -count),
-                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
-                context,
-                "99+0",
-                BigDecimal.valueOf(99 + 0));
+                "7+8",
+                BigDecimal.valueOf(7 + 8));
     }
 
+    // delete row with labels to cell references..................................................................
+
     @Test
-    public void testDeleteRowsWithLabelToDeletedCell() {
+    public void testDeleteRowsWithLabelsToCellUnmodified() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -885,14 +904,94 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
         final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+        final SpreadsheetCellReference c = this.cellReference(0, 5); // E1
 
         cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(b, "20+0+" + LABEL));
+        cellStore.save(this.cell(c, "99+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a));
+
+        final int count = 2;
+        engine.deleteRows(b.row().add(2), count, context); // $c moved, $b unmodified label refs $a also unmodified.
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadLabelAndCheck(labelStore, LABEL, a);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0+" + LABEL,
+                BigDecimal.valueOf(21));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToCellFixed() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 5); // B1
+
+        cellStore.save(this.cell(a, "1+0+" + LABEL));
+        cellStore.save(this.cell(b, "2+0"));
+
         labelStore.save(SpreadsheetLabelMapping.with(LABEL, b));
 
-        final int count = 1;
-        engine.deleteRows(b.row(), count, context); // $b delete
+        final int count = 2;
+        engine.deleteRows(a.row().add(1), count, context); // $b moved
 
-        this.loadLabelFailCheck(labelStore, LABEL);
+        this.countAndCheck(cellStore, 2);
+
+        this.loadLabelAndCheck(labelStore, LABEL, b.add(0, -count));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0+" + LABEL,
+                BigDecimal.valueOf(3));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+0",
+                BigDecimal.valueOf(2));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelToCellReferenceDeleted() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(0, 5); // B1
+
+        cellStore.save(this.cell(a, "1+" + b));
+        cellStore.save(this.cell(b, "2+0"));
+
+        engine.deleteRows(b.row(), 1, context); // $v delete
 
         this.countAndCheck(cellStore, 1);
 
@@ -900,12 +999,12 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                "1+0",
-                BigDecimal.valueOf(1 + 0));
+                "1+InvalidCellReference(" + b + ")",
+                "Invalid cell reference " + b); // reference should have been fixed.
     }
 
     @Test
-    public void testDeleteRowsWithReferences() {
+    public void testDeleteRowsWithCellReferencesFixed() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -958,7 +1057,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testDeleteRowsWithReferences2() {
+    public void testDeleteRowsWithCellReferencesFixed2() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1010,21 +1109,497 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 BigDecimal.valueOf(5 + 2));
     }
 
+    // delete range....................................................................................
+
     @Test
-    public void testDeleteRowsWithReferencesToDeletedCell() {
+    public void testDeleteRowsWithLabelsToRangeUnmodified() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+        final SpreadsheetCellReference d = this.cellReference(0, 15);
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(c, "20+0+" + LABEL));
+        cellStore.save(this.cell(d, "99+0")); // deleted!!!
+
+        final SpreadsheetRange ab = range(a, b);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, ab));
+
+        final int count = 2;
+        engine.deleteRows(d.row(), count, context); // $d moved
+
+        this.countAndCheck(cellStore, 2); // a&c
+        this.countAndCheck(labelStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0+" + LABEL,
+                BigDecimal.valueOf(21));
+
+        this.loadLabelAndCheck(labelStore, LABEL, ab);
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeDeleted() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+
+        cellStore.save(this.cell(a, "1+0"));
+
+        final SpreadsheetRange bc = range(b, c);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bc));
+
+        final int count = c.row().value() - b.row().value() + 1;
+        engine.deleteRows(b.row(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(cellStore, 1); // a
+        this.countAndCheck(labelStore, 0);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeDeleted2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+        final SpreadsheetCellReference d = this.cellReference(0, 20);
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(d, "20+0"));
+
+        final SpreadsheetRange bc = range(b, c);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bc));
+
+        final int count = c.row().value() - b.row().value() + 1;
+        engine.deleteRows(b.row(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(cellStore, 2); // a&d
+        this.countAndCheck(labelStore, 0);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0",
+                BigDecimal.valueOf(20));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeDeleted3() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+
+        cellStore.save(this.cell(a, "1+0+" + LABEL));
+        cellStore.save(this.cell(b, "20+0"));
+
+        final SpreadsheetRange bc = range(b, c);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bc));
+
+        final int count = c.row().value() - b.row().value() + 1;
+        engine.deleteRows(b.row(), count, context); // b..c deleted
+
+        this.countAndCheck(cellStore, 1); // a
+        this.countAndCheck(labelStore, 0);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0+" + LABEL,
+                "Unknown label " + LABEL);
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeFixed() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+        final SpreadsheetCellReference d = this.cellReference(0, 15);
+        final SpreadsheetCellReference e = this.cellReference(0, 20);
+
+        cellStore.save(this.cell(a, "1+0+" + LABEL));
+        cellStore.save(this.cell(d, "20+0"));
+
+        final SpreadsheetRange de = range(d, e);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, de));
+
+        final int count = c.row().value() - b.row().value() + 1;
+        engine.deleteRows(b.row(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(cellStore, 2); // a&d
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0+" + LABEL,
+                BigDecimal.valueOf(1 + 20));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(0, -count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0",
+                BigDecimal.valueOf(20));
+
+        this.countAndCheck(labelStore, 1);
+        this.loadLabelAndCheck(labelStore, LABEL, range(d.add(0, -count), e.add(0, -count)));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeFixed2() {
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+        final SpreadsheetCellReference d = this.cellReference(0, 15);
+        final SpreadsheetCellReference e = this.cellReference(0, 20);
+
+        final SpreadsheetRange ce = range(c, e);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, ce));
+
+        final int count = e.row().value() - d.row().value() + 1;
+        engine.deleteRows(d.row(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(labelStore, 1);
+        this.loadLabelAndCheck(labelStore, LABEL, range(c, d));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeFixed3() {
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+        final SpreadsheetCellReference d = this.cellReference(0, 15);
+
+        final SpreadsheetRange bd = range(b, d);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bd));
+
+        final int count = 1;
+        engine.deleteRows(c.row(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(labelStore, 1);
+
+        this.loadLabelAndCheck(labelStore, LABEL, range(b, d.add(0, -count)));
+    }
+
+    @Test
+    public void testDeleteRowsWithLabelsToRangeFixed4() {
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 5);  // delete
+        final SpreadsheetCellReference b = this.cellReference(0, 10); // range delete
+        final SpreadsheetCellReference c = this.cellReference(0, 15); // range delete
+        final SpreadsheetCellReference d = this.cellReference(0, 20); // range
+        final SpreadsheetCellReference e = this.cellReference(0, 25); // range
+
+        final SpreadsheetRange be = range(b, e);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, be));
+
+        final int count = c.row().value() - a.row().value();
+        engine.deleteRows(a.row(), count, context);
+
+        this.countAndCheck(labelStore, 1);
+
+        this.loadLabelAndCheck(labelStore, LABEL, range(a, b));
+    }
+
+    // deleteColumn....................................................................................................
+
+    @Test
+    public void testDeleteColumnsNone() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference reference = this.cellReference(1, 0); // A2
+
+        cellStore.save(this.cell(reference, "99+0"));
+
+        engine.deleteColumns(reference.column(), 0, context);
+
+        this.countAndCheck(cellStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                reference,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99));
+    }
+
+    @Test
+    public void testDeleteColumnsOne() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
         final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
 
         final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
-        final SpreadsheetCellReference b = this.cellReference(0, 1); // B1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // B1
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // C1
 
-        cellStore.save(this.cell(a, "1+" + b));
-        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+
+        engine.deleteColumns(b.column(), 1, context);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+2",
+                BigDecimal.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "5+6",
+                BigDecimal.valueOf(5 + 6));
+    }
+
+    @Test
+    public void testDeleteColumnsOne2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); //
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // replaced by c
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // DELETED
+        final SpreadsheetCellReference d = this.cellReference(9, 1); // moved
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+        cellStore.save(this.cell(d, "7+8"));
 
         final int count = 1;
-        engine.deleteRows(b.row(), count, context); // $c delete
+        engine.deleteColumns(b.column(), count, context); // $b delete
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+2",
+                BigDecimal.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "5+6",
+                BigDecimal.valueOf(5 + 6));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "7+8",
+                BigDecimal.valueOf(7 + 8));
+    }
+
+    @Test
+    public void testDeleteColumnsMany() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); //
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // replaced by c
+        final SpreadsheetCellReference c = this.cellReference(2, 0); // DELETED
+        final SpreadsheetCellReference d = this.cellReference(9, 1); // moved
+
+        cellStore.save(this.cell(a, "1+2"));
+        cellStore.save(this.cell(b, "3+4"));
+        cellStore.save(this.cell(c, "5+6"));
+        cellStore.save(this.cell(d, "7+8"));
+
+        final int count = 2;
+        engine.deleteColumns(b.column(), count, context); // $b, $c deleted
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+2",
+                BigDecimal.valueOf(1 + 2));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "7+8",
+                BigDecimal.valueOf(7 + 8));
+    }
+
+    // delete column with labels to cell references..................................................................
+
+    @Test
+    public void testDeleteColumnsWithLabelsToCellUnmodified() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // B1
+        final SpreadsheetCellReference c = this.cellReference(5, 0); // E1
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(b, "20+0+" + LABEL));
+        cellStore.save(this.cell(c, "99+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a));
+
+        final int count = 2;
+        engine.deleteColumns(b.column().add(2), count, context); // $c moved, $b unmodified label refs $a also unmodified.
+
+        this.countAndCheck(cellStore, 3);
+
+        this.loadLabelAndCheck(labelStore, LABEL, a);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0+" + LABEL,
+                BigDecimal.valueOf(21));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToCellFixed() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(5, 0); // B1
+
+        cellStore.save(this.cell(a, "1+0+" + LABEL));
+        cellStore.save(this.cell(b, "2+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, b));
+
+        final int count = 2;
+        engine.deleteColumns(a.column().add(1), count, context); // $b moved
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadLabelAndCheck(labelStore, LABEL, b.add(-count, 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0+" + LABEL,
+                BigDecimal.valueOf(3));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+0",
+                BigDecimal.valueOf(2));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelToCellReferenceDeleted() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(5, 0); // B1
+
+        cellStore.save(this.cell(a, "1+" + b));
+        cellStore.save(this.cell(b, "2+0"));
+
+        engine.deleteColumns(b.column(), 1, context); // $v delete
 
         this.countAndCheck(cellStore, 1);
 
@@ -1033,62 +1608,365 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "1+InvalidCellReference(" + b + ")",
-                "Invalid cell reference " + b); // reference should have been fixed.;
+                "Invalid cell reference " + b); // reference should have been fixed.
     }
 
     @Test
-    public void testDeleteRowsSeveral() {
+    public void testDeleteColumnsWithCellReferencesFixed() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
         final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
 
         final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
-        final SpreadsheetCellReference b = this.cellReference(0, 10); // H1 DELETED
-        final SpreadsheetCellReference c = this.cellReference(0, 11); // I1 DELETED
-        final SpreadsheetCellReference d = this.cellReference(2, 12); // L3
-        final SpreadsheetCellReference e = this.cellReference(3, 20); // T4
-        final SpreadsheetCellReference f = this.cellReference(4, 21); // U5
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // B1
+        final SpreadsheetCellReference c = this.cellReference(10, 0); // A10 deleted
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // H13 moved
+        final SpreadsheetCellReference e = this.cellReference(14, 9); // I14 moved
 
-        cellStore.save(this.cell(a, "1"));
+        cellStore.save(this.cell(a, "1+" + d));
         cellStore.save(this.cell(b, "2"));
         cellStore.save(this.cell(c, "3"));
         cellStore.save(this.cell(d, "4"));
-        cellStore.save(this.cell(e, "5"));
-        cellStore.save(this.cell(f, "6"));
+        cellStore.save(this.cell(e, "5+" + b)); // =5+2
 
-        final int count = 5;
-        engine.deleteRows(this.row(7), count, context); // $b & $c
+        final int count = 1;
+        engine.deleteColumns(c.column(), count, context); // $c delete
 
         this.countAndCheck(cellStore, 4);
 
-        this.loadCellAndCheckFormatted2(engine,
+        this.loadCellAndCheckFormulaAndValue(engine,
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(1),
+                "1+" + d.add(-count, 0),
+                BigDecimal.valueOf(1 + 4)); // reference should have been fixed.
+
+        this.loadCellAndCheckFormatted2(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                BigDecimal.valueOf(2),
                 DEFAULT_SUFFIX);
 
         this.loadCellAndCheckFormatted2(engine,
-                d.add(0, -count),
+                d.add(-count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 BigDecimal.valueOf(4),
                 DEFAULT_SUFFIX);
 
-        this.loadCellAndCheckFormatted2(engine,
-                e.add(0, -count),
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(-count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(5),
+                "5+" + b,
+                BigDecimal.valueOf(5 + 2));
+    }
+
+    @Test
+    public void testDeleteColumnsWithCellReferencesFixed2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(1, 0); // B1
+        final SpreadsheetCellReference c = this.cellReference(10, 0); // J1 deleted
+        final SpreadsheetCellReference d = this.cellReference(13, 8); // M8 moved
+        final SpreadsheetCellReference e = this.cellReference(14, 9); // N9 moved
+
+        cellStore.save(this.cell(a, "1+" + d));
+        cellStore.save(this.cell(b, "2"));
+        cellStore.save(this.cell(c, "3"));
+        cellStore.save(this.cell(d, "4"));
+        cellStore.save(this.cell(e, "5+" + b)); // =5+2
+
+        final int count = 2;
+        engine.deleteColumns(c.column(), count, context); // $c delete
+
+        this.countAndCheck(cellStore, 4);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+" + d.add(-count, 0),
+                BigDecimal.valueOf(1 + 4)); // reference should have been fixed.
+
+        this.loadCellAndCheckFormatted2(engine,
+                b,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                BigDecimal.valueOf(2),
                 DEFAULT_SUFFIX);
 
         this.loadCellAndCheckFormatted2(engine,
-                f.add(0, -count),
+                d.add(-count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                BigDecimal.valueOf(6),
+                BigDecimal.valueOf(4),
                 DEFAULT_SUFFIX);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                e.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "5+" + b,
+                BigDecimal.valueOf(5 + 2));
+    }
+
+    // delete range....................................................................................
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeUnmodified() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+        final SpreadsheetCellReference d = this.cellReference(15, 0);
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(c, "20+0+" + LABEL));
+        cellStore.save(this.cell(d, "99+0")); // deleted!!!
+
+        final SpreadsheetRange ab = range(a, b);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, ab));
+
+        final int count = 2;
+        engine.deleteColumns(d.column(), count, context); // $d moved
+
+        this.countAndCheck(cellStore, 2); // a&c
+        this.countAndCheck(labelStore, 1);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                c,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0+" + LABEL,
+                BigDecimal.valueOf(21));
+
+        this.loadLabelAndCheck(labelStore, LABEL, ab);
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeDeleted() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+
+        cellStore.save(this.cell(a, "1+0"));
+
+        final SpreadsheetRange bc = range(b, c);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bc));
+
+        final int count = c.column().value() - b.column().value() + 1;
+        engine.deleteColumns(b.column(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(cellStore, 1); // a
+        this.countAndCheck(labelStore, 0);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeDeleted2() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+        final SpreadsheetCellReference d = this.cellReference(20, 0);
+
+        cellStore.save(this.cell(a, "1+0"));
+        cellStore.save(this.cell(d, "20+0"));
+
+        final SpreadsheetRange bc = range(b, c);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bc));
+
+        final int count = c.column().value() - b.column().value() + 1;
+        engine.deleteColumns(b.column(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(cellStore, 2); // a&d
+        this.countAndCheck(labelStore, 0);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0",
+                BigDecimal.valueOf(1));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0",
+                BigDecimal.valueOf(20));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeDeleted3() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+
+        cellStore.save(this.cell(a, "1+0+" + LABEL));
+        cellStore.save(this.cell(b, "20+0"));
+
+        final SpreadsheetRange bc = range(b, c);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bc));
+
+        final int count = c.column().value() - b.column().value() + 1;
+        engine.deleteColumns(b.column(), count, context); // b..c deleted
+
+        this.countAndCheck(cellStore, 1); // a
+        this.countAndCheck(labelStore, 0);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0+" + LABEL,
+                "Unknown label " + LABEL);
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeFixed() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+        final SpreadsheetCellReference d = this.cellReference(15, 0);
+        final SpreadsheetCellReference e = this.cellReference(20, 0);
+
+        cellStore.save(this.cell(a, "1+0+" + LABEL));
+        cellStore.save(this.cell(d, "20+0"));
+
+        final SpreadsheetRange de = range(d, e);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, de));
+
+        final int count = c.column().value() - b.column().value() + 1;
+        engine.deleteColumns(b.column(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(cellStore, 2); // a&d
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+0+" + LABEL,
+                BigDecimal.valueOf(1 + 20));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d.add(-count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "20+0",
+                BigDecimal.valueOf(20));
+
+        this.countAndCheck(labelStore, 1);
+        this.loadLabelAndCheck(labelStore, LABEL, range(d.add(-count, 0), e.add(-count, 0)));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeFixed2() {
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+        final SpreadsheetCellReference d = this.cellReference(15, 0);
+        final SpreadsheetCellReference e = this.cellReference(20, 0);
+
+        final SpreadsheetRange ce = range(c, e);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, ce));
+
+        final int count = e.column().value() - d.column().value() + 1;
+        engine.deleteColumns(d.column(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(labelStore, 1);
+        this.loadLabelAndCheck(labelStore, LABEL, range(c, d));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeFixed3() {
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+        final SpreadsheetCellReference d = this.cellReference(15, 0);
+
+        final SpreadsheetRange bd = range(b, d);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, bd));
+
+        final int count = 1;
+        engine.deleteColumns(c.column(), count, context); // b..c deleted, d moved
+
+        this.countAndCheck(labelStore, 1);
+
+        this.loadLabelAndCheck(labelStore, LABEL, range(b, d.add(-count, 0)));
+    }
+
+    @Test
+    public void testDeleteColumnsWithLabelsToRangeFixed4() {
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(5, 0);  // delete
+        final SpreadsheetCellReference b = this.cellReference(10, 0); // range delete
+        final SpreadsheetCellReference c = this.cellReference(15, 0); // range delete
+        final SpreadsheetCellReference d = this.cellReference(20, 0); // range
+        final SpreadsheetCellReference e = this.cellReference(25, 0); // range
+
+        final SpreadsheetRange be = range(b, e);
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, be));
+
+        final int count = c.column().value() - a.column().value();
+        engine.deleteColumns(a.column(), count, context);
+
+        this.countAndCheck(labelStore, 1);
+
+        this.loadLabelAndCheck(labelStore, LABEL, range(a, b));
     }
 
     // insertColumn....................................................................................................
@@ -1174,7 +2052,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         cellStore.save(this.cell(c, "5+6"));
 
         final int count = 1;
-        engine.insertColumns(b.column(), count, context); // $b insert, $c,$d columns -1.
+        engine.insertColumns(b.column(), count, context); // $b insert
 
         this.countAndCheck(cellStore, 3);
 
@@ -1186,14 +2064,14 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 BigDecimal.valueOf(1 + 2));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                b.add(+count, 0),
+                b.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "3+4",
                 BigDecimal.valueOf(3 + 4));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                c.add(+count, 0),
+                c.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "5+6",
@@ -1201,7 +2079,44 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertColumnsWithLabels() {
+    public void testInsertColumnsWithLabelToCellIgnored() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(2, 1); // A1
+        final SpreadsheetCellReference b = this.cellReference(4, 3); // A2 moved
+
+        cellStore.save(this.cell(a, "100"));
+        cellStore.save(this.cell(b, "2+" + LABEL));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a));
+
+        final int count = 1;
+        engine.insertColumns(b.column(), count, context); // $b insert
+
+        this.loadLabelAndCheck(labelStore, LABEL, a);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "100",
+                BigDecimal.valueOf(100));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+" + LABEL,
+                BigDecimal.valueOf(2 + 100));
+    }
+
+    @Test
+    public void testInsertColumnsWithLabelToCell() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1222,7 +2137,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         final int count = 1;
         engine.insertColumns(b.column(), count, context); // $b insert
 
-        this.loadLabelAndCheck(labelStore, LABEL, d.add(+count, 0));
+        this.loadLabelAndCheck(labelStore, LABEL, d.add(count, 0));
 
         this.countAndCheck(cellStore, 4);
 
@@ -1234,21 +2149,21 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 BigDecimal.valueOf(1 + 99));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                b.add(+count, 0),
+                b.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "2+0",
                 BigDecimal.valueOf(2 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                c.add(+count, 0),
+                c.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "3+0+" + LABEL,
                 BigDecimal.valueOf(3 + 99));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                d.add(+count, 0),
+                d.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "99+0",
@@ -1256,7 +2171,87 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertColumnsWithReferences() {
+    public void testInsertColumnsWithLabelToRangeUnchanged() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(5, 5); // A2 moved
+
+        cellStore.save(this.cell(a, "99+0"));
+        cellStore.save(this.cell(b, "2+0+" + LABEL));
+
+        final SpreadsheetRange a1 = SpreadsheetRange.with(a, a.add(1, 1));
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a1));
+
+        final int count = 1;
+        engine.insertColumns(b.column(), count, context); // $b insert
+
+        this.countAndCheck(labelStore, 1);
+
+        this.loadLabelAndCheck(labelStore, LABEL, a1);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(count, 0),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+0+" + LABEL,
+                BigDecimal.valueOf(2 + 99));
+    }
+
+    @Test
+    public void testInsertColumnsWithLabelToRangeUpdated() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(5, 0);
+        final SpreadsheetCellReference c = this.cellReference(10, 0);
+        final SpreadsheetCellReference d = this.cellReference(15, 0);
+        final SpreadsheetCellReference e = this.cellReference(20, 0);
+
+        cellStore.save(this.cell(a, "1+" + LABEL));
+        cellStore.save(this.cell(c, "99+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, SpreadsheetRange.with(c, d)));
+
+        engine.insertColumns(b.column(), c.column().value() - b.column().value(), context); // $b insert
+
+        this.countAndCheck(labelStore, 1);
+        this.loadLabelAndCheck(labelStore, LABEL, SpreadsheetRange.with(d, e));
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+" + LABEL,
+                BigDecimal.valueOf(1 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99 + 0));
+    }
+
+    @Test
+    public void testInsertColumnsWithCellReferences() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1281,7 +2276,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                "1+0+" + d.add(+count, 0),
+                "1+0+" + d.add(count, 0),
                 BigDecimal.valueOf(1 + 0 + 4 + 2)); // reference should have been fixed.
 
         this.loadCellAndCheckFormulaAndValue(engine,
@@ -1292,14 +2287,14 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 BigDecimal.valueOf(2));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                c.add(+count, 0),
+                c.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "3+0",
                 BigDecimal.valueOf(3));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                d.add(+count, 0),
+                d.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "4+0+" + b,
@@ -1307,7 +2302,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertColumnsWithReferences2() {
+    public void testInsertColumnsWithCellReferences2() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1332,7 +2327,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 a,
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
-                "1+0+" + d.add(+count, 0),
+                "1+0+" + d.add(count, 0),
                 BigDecimal.valueOf(1 + 0 + 4 + 2)); // reference should have been fixed.
 
         this.loadCellAndCheckFormulaAndValue(engine,
@@ -1343,14 +2338,14 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 BigDecimal.valueOf(2 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                c.add(+count, 0),
+                c.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "3+0",
                 BigDecimal.valueOf(3 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                d.add(+count, 0),
+                d.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "4+0+" + b,
@@ -1364,11 +2359,11 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
         final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
 
-        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
-        final SpreadsheetCellReference b = this.cellReference(10, 0); // A2 MOVED
-        final SpreadsheetCellReference c = this.cellReference(11, 0); // A3 MOVED
-        final SpreadsheetCellReference d = this.cellReference(12, 2); // C4 MOVED
-        final SpreadsheetCellReference e = this.cellReference(20, 3); // T3 MOVED
+        final SpreadsheetCellReference a = this.cellReference(0, 0); //
+        final SpreadsheetCellReference b = this.cellReference(10, 0); // MOVED
+        final SpreadsheetCellReference c = this.cellReference(11, 0); // MOVED
+        final SpreadsheetCellReference d = this.cellReference(12, 2); // MOVED
+        final SpreadsheetCellReference e = this.cellReference(20, 3); // MOVED
 
         cellStore.save(this.cell(a, "1+0"));
         cellStore.save(this.cell(b, "2+0"));
@@ -1389,28 +2384,28 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 BigDecimal.valueOf(1 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                b.add(+count, 0),
+                b.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "2+0",
                 BigDecimal.valueOf(2 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                c.add(+count, 0),
+                c.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "3+0",
                 BigDecimal.valueOf(3 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                d.add(+count, 0),
+                d.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "4+0",
                 BigDecimal.valueOf(4 + 0));
 
         this.loadCellAndCheckFormulaAndValue(engine,
-                e.add(+count, 0),
+                e.add(count, 0),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "5+0",
@@ -1420,7 +2415,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     // insertRow....................................................................................................
 
     @Test
-    public void testInsertRowZero() {
+    public void testInsertRowsZero() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1443,7 +2438,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertRow() {
+    public void testInsertRows() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1485,7 +2480,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertRow2() {
+    public void testInsertRows2() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1527,7 +2522,44 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertRowWithLabels() {
+    public void testInsertRowsWithLabelToCellIgnored() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(1, 2); // A1
+        final SpreadsheetCellReference b = this.cellReference(3, 4); // A2 moved
+
+        cellStore.save(this.cell(a, "100"));
+        cellStore.save(this.cell(b, "2+" + LABEL));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a));
+
+        final int count = 1;
+        engine.insertRows(b.row(), count, context); // $b insert
+
+        this.loadLabelAndCheck(labelStore, LABEL, a);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "100",
+                BigDecimal.valueOf(100));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+" + LABEL,
+                BigDecimal.valueOf(2 + 100));
+    }
+
+    @Test
+    public void testInsertRowsWithLabelToCell() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1582,7 +2614,87 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertRowWithReferences() {
+    public void testInsertRowsWithLabelToRangeUnchanged() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0); // A1
+        final SpreadsheetCellReference b = this.cellReference(5, 5); // A2 moved
+
+        cellStore.save(this.cell(a, "99+0"));
+        cellStore.save(this.cell(b, "2+0+" + LABEL));
+
+        final SpreadsheetRange a1 = SpreadsheetRange.with(a, a.add(1, 1));
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, a1));
+
+        final int count = 1;
+        engine.insertRows(b.row(), count, context); // $b insert
+
+        this.countAndCheck(labelStore, 1);
+
+        this.loadLabelAndCheck(labelStore, LABEL, a1);
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99 + 0));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                b.add(0, +count),
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "2+0+" + LABEL,
+                BigDecimal.valueOf(2 + 99));
+    }
+
+    @Test
+    public void testInsertRowsWithLabelToRangeUpdated() {
+        final SpreadsheetCellStore cellStore = this.cellStore();
+        final SpreadsheetLabelStore labelStore = this.labelStore();
+        final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
+        final SpreadsheetEngineContext context = this.createContext(labelStore, engine);
+
+        final SpreadsheetCellReference a = this.cellReference(0, 0);
+        final SpreadsheetCellReference b = this.cellReference(0, 5);
+        final SpreadsheetCellReference c = this.cellReference(0, 10);
+        final SpreadsheetCellReference d = this.cellReference(0, 15);
+        final SpreadsheetCellReference e = this.cellReference(0, 20);
+
+        cellStore.save(this.cell(a, "1+" + LABEL));
+        cellStore.save(this.cell(c, "99+0"));
+
+        labelStore.save(SpreadsheetLabelMapping.with(LABEL, SpreadsheetRange.with(c, d)));
+
+        engine.insertRows(b.row(), c.row().value() - b.row().value(), context); // $b insert
+
+        this.countAndCheck(labelStore, 1);
+        this.loadLabelAndCheck(labelStore, LABEL, SpreadsheetRange.with(d, e));
+
+        this.countAndCheck(cellStore, 2);
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                a,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "1+" + LABEL,
+                BigDecimal.valueOf(1 + 99));
+
+        this.loadCellAndCheckFormulaAndValue(engine,
+                d,
+                SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
+                context,
+                "99+0",
+                BigDecimal.valueOf(99 + 0));
+    }
+
+    @Test
+    public void testInsertRowsWithCellReferences() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1633,7 +2745,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertRowWithReferences2() {
+    public void testInsertRowsWithCellReferences2() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1684,7 +2796,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     @Test
-    public void testInsertRowSeveral() {
+    public void testInsertRowsSeveral() {
         final SpreadsheetCellStore cellStore = this.cellStore();
         final SpreadsheetLabelStore labelStore = this.labelStore();
         final BasicSpreadsheetEngine engine = this.createSpreadsheetEngine(cellStore, labelStore);
@@ -1765,7 +2877,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellA), SpreadsheetRange.with(d, d.add(1,1)), context);
+        engine.copy(Lists.of(cellA), SpreadsheetRange.with(d, d.add(1, 1)), context);
 
         this.countAndCheck(cellStore, 3 + 1);
 
@@ -1797,9 +2909,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2,2)), context);
+        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2, 2)), context);
 
-        this.countAndCheck(cellStore, 3+2);
+        this.countAndCheck(cellStore, 3 + 2);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -1836,9 +2948,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(1,1)), context);
+        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(1, 1)), context);
 
-        this.countAndCheck(cellStore, 3+2);
+        this.countAndCheck(cellStore, 3 + 2);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -1875,9 +2987,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2,2)), context);
+        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2, 2)), context);
 
-        this.countAndCheck(cellStore, 3+2);
+        this.countAndCheck(cellStore, 3 + 2);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -1914,9 +3026,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(7,2)), context);
+        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(7, 2)), context);
 
-        this.countAndCheck(cellStore, 3+6);
+        this.countAndCheck(cellStore, 3 + 6);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -1981,9 +3093,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2,7)), context);
+        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2, 7)), context);
 
-        this.countAndCheck(cellStore, 3+6);
+        this.countAndCheck(cellStore, 3 + 6);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -2045,9 +3157,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
         final SpreadsheetCellReference d = this.cellReference(30, 40);
 
-        engine.copy(Lists.of(cellB), SpreadsheetRange.with(d, d.add(1,1)), context);
+        engine.copy(Lists.of(cellB), SpreadsheetRange.with(d, d.add(1, 1)), context);
 
-        this.countAndCheck(cellStore, 2+1);
+        this.countAndCheck(cellStore, 2 + 1);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -2076,9 +3188,9 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
         final SpreadsheetCellReference d = SpreadsheetReferenceKind.RELATIVE.column(30)
                 .setRow(SpreadsheetReferenceKind.RELATIVE.row(40));
 
-        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2,2)), context);
+        engine.copy(Lists.of(cellA, cellB), SpreadsheetRange.with(d, d.add(2, 2)), context);
 
-        this.countAndCheck(cellStore, 2+2);
+        this.countAndCheck(cellStore, 2 + 2);
 
         this.loadCellAndCheckFormulaAndValue(engine,
                 d,
@@ -2087,7 +3199,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
                 "" + d.add(1, 1),
                 BigDecimal.valueOf(2 + 0));
         this.loadCellAndCheckFormulaAndValue(engine,
-                d.add(1,1),
+                d.add(1, 1),
                 SpreadsheetEngineLoading.COMPUTE_IF_NECESSARY,
                 context,
                 "2+0",
@@ -2095,7 +3207,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     //  helpers.......................................................................................................
-    
+
     @Override
     protected BasicSpreadsheetEngine createSpreadsheetEngine() {
         return this.createSpreadsheetEngine(this.cellStore());
@@ -2103,6 +3215,10 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
     private BasicSpreadsheetEngine createSpreadsheetEngine(final SpreadsheetCellStore cellStore) {
         return this.createSpreadsheetEngine(cellStore, this.labelStore());
+    }
+
+    private BasicSpreadsheetEngine createSpreadsheetEngine(final SpreadsheetLabelStore labelStore) {
+        return this.createSpreadsheetEngine(this.cellStore(), labelStore);
     }
 
     private BasicSpreadsheetEngine createSpreadsheetEngine(final SpreadsheetCellStore cellStore,
@@ -2118,6 +3234,7 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     private SpreadsheetEngineContext createContext(final BasicSpreadsheetEngine engine) {
         return this.createContext(SpreadsheetLabelStores.fake(), engine);
     }
+
     private SpreadsheetEngineContext createContext(final SpreadsheetLabelStore labelStore,
                                                    final BasicSpreadsheetEngine engine) {
         return new FakeSpreadsheetEngineContext() {
@@ -2149,13 +3266,13 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
             @Override
             public SpreadsheetTextFormatter<?> parseFormatPattern(final String pattern) {
-                if(PATTERN_COLOR.equals(pattern)){
+                if (PATTERN_COLOR.equals(pattern)) {
                     return formatter(pattern, COLOR, PATTERN_SUFFIX);
                 }
-                if(PATTERN.equals(pattern)) {
+                if (PATTERN.equals(pattern)) {
                     return formatter(pattern, SpreadsheetFormattedText.WITHOUT_COLOR, PATTERN_SUFFIX);
                 }
-                if(PATTERN_FORMAT_FAIL.equals(pattern)) {
+                if (PATTERN_FORMAT_FAIL.equals(pattern)) {
                     return SpreadsheetTextFormatters.fixed(Object.class, Optional.empty());
                 }
 
@@ -2199,11 +3316,11 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
     }
 
     private SpreadsheetCell loadCellAndCheckFormatted2(final SpreadsheetEngine engine,
-                                                               final SpreadsheetCellReference reference,
-                                                               final SpreadsheetEngineLoading loading,
-                                                               final SpreadsheetEngineContext context,
-                                                               final Object value,
-                                                               final String suffix) {
+                                                       final SpreadsheetCellReference reference,
+                                                       final SpreadsheetEngineLoading loading,
+                                                       final SpreadsheetEngineContext context,
+                                                       final Object value,
+                                                       final String suffix) {
         final SpreadsheetCell cell = this.loadCellAndCheckValue(engine, reference, loading, context, value);
         this.checkFormattedText(cell, value + " " + suffix);
         return cell;
@@ -2231,6 +3348,18 @@ public final class BasicSpreadsheetEngineTest extends SpreadsheetEngineTestCase<
 
     private SpreadsheetCellReference cellReference(final int column, final int row) {
         return SpreadsheetReferenceKind.ABSOLUTE.column(column).setRow(SpreadsheetReferenceKind.ABSOLUTE.row(row));
+    }
+
+    private SpreadsheetRange range(final int beginColumn, final int beginRow, final int endColumn, final int endRow) {
+        return range(cellReference(beginColumn, beginRow), cellReference(endColumn, endRow));
+    }
+
+    private SpreadsheetRange range(final SpreadsheetCellReference begin, final int endColumn, final int endRow) {
+        return range(begin, cellReference(endColumn, endRow));
+    }
+
+    private SpreadsheetRange range(final SpreadsheetCellReference begin, final SpreadsheetCellReference end) {
+        return SpreadsheetRange.with(begin, end);
     }
 
     private SpreadsheetCell cell(final SpreadsheetCellReference reference, final String formula) {


### PR DESCRIPTION
…y only cell.

- BasicSpreadsheetEngine fix cell and range references.
- Additional tests for inserting/deleting columns and rows.
- SpreadsheetRange: now implements ExpressionReference.
- internal naming and method improvements to BasicSpreadsheetEngine* collaborators.