### PR TITLE
SpreadsheetDelta.setCells/setWindows.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCell.java
@@ -334,7 +334,8 @@ public final class SpreadsheetCell implements HashCodeEqualsDefined,
 
     @Override
     public void buildToString(final ToStringBuilder builder) {
-        builder.label(this.reference.toString())
+        builder.labelSeparator("=")
+                .label(this.reference.toString())
                 .value(this.formula)
                 .value(this.style)
                 .value(this.format)

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetDelta.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetDelta.java
@@ -1,34 +1,73 @@
 package walkingkooka.spreadsheet;
 
 import walkingkooka.Cast;
+import walkingkooka.build.tostring.ToStringBuilder;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
+import walkingkooka.compare.Range;
 import walkingkooka.net.http.server.hateos.HateosResource;
 import walkingkooka.test.HashCodeEqualsDefined;
+import walkingkooka.text.CharacterConstant;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
 import walkingkooka.tree.json.HasJsonNode;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonNodeException;
 import walkingkooka.tree.json.JsonNodeName;
+import walkingkooka.tree.json.JsonObjectNode;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Captures changes following an operation.
  */
-public final class SpreadsheetDelta implements HashCodeEqualsDefined, HateosResource<SpreadsheetId> {
+public abstract class SpreadsheetDelta implements HashCodeEqualsDefined, HateosResource<SpreadsheetId> {
 
     public final static Set<SpreadsheetCell> NO_CELLS = Sets.empty();
 
-    public static SpreadsheetDelta with(final SpreadsheetId id, final Set<SpreadsheetCell> cells) {
+    /**
+     * Factory that creates a new {@link SpreadsheetDelta}
+     */
+    public static SpreadsheetDelta with(final SpreadsheetId id,
+                                        final Set<SpreadsheetCell> cells) {
         Objects.requireNonNull(id, "id");
-        Objects.requireNonNull(cells, "cells");
+        checkCells(cells);
 
-        final Set<SpreadsheetCell> copy = Sets.ordered();
-        copy.addAll(cells);
-        return new SpreadsheetDelta(id, Sets.readOnly(cells));
+        return nonWindowed(id, cells);
     }
 
-    private SpreadsheetDelta(final SpreadsheetId id, final Set<SpreadsheetCell> cells) {
+    static SpreadsheetDelta filterCellsIfNecessaryAndCreate(final SpreadsheetId id,
+                                                            final Set<SpreadsheetCell> cells,
+                                                            final List<Range<SpreadsheetCellReference>> window) {
+        return null == window || window.isEmpty() ?
+                nonWindowed(id, cells) :
+                windowed(id,
+                        filterCells(cells, window),
+                        Lists.readOnly(window));
+    }
+
+    /**
+     * Factory that creates a {@link SpreadsheetDeltaNonWindowed}
+     */
+    static SpreadsheetDeltaNonWindowed nonWindowed(final SpreadsheetId id,
+                                                   final Set<SpreadsheetCell> cells) {
+        return SpreadsheetDeltaNonWindowed.with0(id, copyCells(cells));
+    }
+
+    /**
+     * Factory that creates a {@link SpreadsheetDeltaWindowed}
+     */
+    static SpreadsheetDeltaWindowed windowed(final SpreadsheetId id,
+                                             final Set<SpreadsheetCell> cells,
+                                             final List<Range<SpreadsheetCellReference>> window) {
+        return SpreadsheetDeltaWindowed.with0(id, cells, window);
+    }
+
+    SpreadsheetDelta(final SpreadsheetId id,
+                     final Set<SpreadsheetCell> cells) {
         super();
 
         this.id = id;
@@ -40,13 +79,73 @@ public final class SpreadsheetDelta implements HashCodeEqualsDefined, HateosReso
         return this.id;
     }
 
-    private final SpreadsheetId id;
+    final SpreadsheetId id;
 
-    public Set<SpreadsheetCell> cells() {
+    // cells............................................................................................................
+
+    public final Set<SpreadsheetCell> cells() {
         return this.cells;
     }
 
-    private final Set<SpreadsheetCell> cells;
+    /**
+     * Would be setter that returns {@link SpreadsheetDelta}
+     */
+    public abstract SpreadsheetDelta setCells(final Set<SpreadsheetCell> cells);
+
+    final Set<SpreadsheetCell> cells;
+
+    static void checkCells(final Set<SpreadsheetCell> cells) {
+        Objects.requireNonNull(cells, "cells");
+    }
+
+    /**
+     * Makes a copy of the cells without any filtering.
+     */
+    static Set<SpreadsheetCell> copyCells(final Set<SpreadsheetCell> cells) {
+        final Set<SpreadsheetCell> copy = Sets.ordered();
+        copy.addAll(cells);
+        return Sets.readOnly(cells);
+    }
+
+    /**
+     * Filters the cells using the assumed window of {@link Range cell reference ranges}.
+     */
+    static Set<SpreadsheetCell> filterCells(final Set<SpreadsheetCell> cells,
+                                                    final List<Range<SpreadsheetCellReference>> window) {
+        return cells.stream()
+                .filter(c -> window.stream().anyMatch(r -> r.test(c.reference())))
+                .collect(Collectors.toCollection(Sets::ordered));
+    }
+
+    // window............................................................................................................
+
+    /**
+     * Getter that returns any windows for this delta. An empty list signifies, no filtering.
+     */
+    public abstract List<Range<SpreadsheetCellReference>> window();
+
+    /**
+     * Would be setter that if necessary returns a new {@link SpreadsheetDelta} which will also filter cells if necessary.
+     */
+    public final SpreadsheetDelta setWindow(final List<Range<SpreadsheetCellReference>> window) {
+        final List<Range<SpreadsheetCellReference>> copy = copyWindow(window);
+
+        return this.window().equals(copy) ?
+               this :
+                filterCellsIfNecessaryAndCreate(this.id, this.cells, copy);
+    }
+
+    /**
+     * Checks and makes a copy of the window ranges.
+     */
+    private static List<Range<SpreadsheetCellReference>> copyWindow(final List<Range<SpreadsheetCellReference>> window) {
+        Objects.requireNonNull(window, "window");
+
+        final List<Range<SpreadsheetCellReference>> copy = Lists.array();
+        copy.addAll(window);
+
+        return copy;
+    }
 
     // HasJsonNode...................................................................................................
 
@@ -58,6 +157,7 @@ public final class SpreadsheetDelta implements HashCodeEqualsDefined, HateosReso
 
         SpreadsheetId id = null;
         Set<SpreadsheetCell> cells = null;
+        List<Range<SpreadsheetCellReference>> window = null;
 
         try {
             for (JsonNode child : node.objectOrFail().children()) {
@@ -68,6 +168,9 @@ public final class SpreadsheetDelta implements HashCodeEqualsDefined, HateosReso
                         break;
                     case CELLS_PROPERTY_STRING:
                         cells = child.fromJsonNodeSet(SpreadsheetCell.class);
+                        break;
+                    case WINDOW_PROPERTY_STRING:
+                        window = windowFromJsonNode(child.stringValueOrFail());
                         break;
                     default:
                         throw new IllegalArgumentException("Unknown property " + name + "=" + node);
@@ -84,26 +187,40 @@ public final class SpreadsheetDelta implements HashCodeEqualsDefined, HateosReso
             HasJsonNode.requiredPropertyMissing(CELLS_PROPERTY, node);
         }
 
-        return new SpreadsheetDelta(id, cells);
+        return SpreadsheetDelta.filterCellsIfNecessaryAndCreate(id, cells, window);
     }
 
-    @Override
-    public JsonNode toJsonNode() {
+    private static List<Range<SpreadsheetCellReference>> windowFromJsonNode(final String range) {
+        return Arrays.stream(range.split(WINDOW_SEPARATOR))
+                .map(SpreadsheetCellReference::parseRange)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Creates a {@link JsonObjectNode} with the id and cells.
+     */
+    final JsonObjectNode toJsonNodeIdAndCells() {
         return JsonNode.object()
                 .set(ID_PROPERTY, this.id.toJsonNode())
                 .set(CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells));
     }
 
+    final static String WINDOW_SEPARATOR =",";
+
     private final static String ID_PROPERTY_STRING = "id";
     private final static String CELLS_PROPERTY_STRING = "cells";
+    private final static String WINDOW_PROPERTY_STRING = "window";
 
     final static JsonNodeName ID_PROPERTY = JsonNodeName.with(ID_PROPERTY_STRING);
     final static JsonNodeName CELLS_PROPERTY = JsonNodeName.with(CELLS_PROPERTY_STRING);
+    final static JsonNodeName WINDOW_PROPERTY = JsonNodeName.with(WINDOW_PROPERTY_STRING);
 
     static {
         HasJsonNode.register("spreadsheet-delta",
                 SpreadsheetDelta::fromJsonNode,
-                SpreadsheetDelta.class);
+                SpreadsheetDelta.class,
+                SpreadsheetDeltaNonWindowed.class,
+                SpreadsheetDeltaWindowed.class);
     }
 
     // equals...................................................................................................
@@ -114,19 +231,30 @@ public final class SpreadsheetDelta implements HashCodeEqualsDefined, HateosReso
     }
 
     @Override
-    public boolean equals(final Object other) {
+    public final boolean equals(final Object other) {
         return this == other ||
-                other instanceof SpreadsheetDelta &&
+                this.canBeEquals(other) &&
                         this.equals0(Cast.to(other));
     }
 
+    abstract boolean canBeEquals(final Object other);
+
     private boolean equals0(final SpreadsheetDelta other) {
         return this.id.equals(other.id) &&
-                this.cells.equals(other.cells);
+                this.cells.equals(other.cells) &&
+                this.equals1(other);
     }
 
+    abstract boolean equals1(final SpreadsheetDelta other);
+
     @Override
-    public String toString() {
-        return this.cells.toString();
+    public final String toString() {
+        return ToStringBuilder.empty()
+                .labelSeparator(": ")
+                .separator(" ")
+                .valueSeparator(",")
+                .label("cells").value(this.cells)
+                .label("window").value(this.window())
+                .build();
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetDeltaNonWindowed.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetDeltaNonWindowed.java
@@ -1,0 +1,62 @@
+package walkingkooka.spreadsheet;
+
+import walkingkooka.build.tostring.ToStringBuilder;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.compare.Range;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.tree.json.JsonNode;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@link SpreadsheetDelta} without any window/filtering.
+ */
+final class SpreadsheetDeltaNonWindowed extends SpreadsheetDelta {
+
+    /**
+     * Factory that creates a new {@link SpreadsheetDeltaNonWindowed} without copying or filtering the cells.
+     */
+    static SpreadsheetDeltaNonWindowed with0(final SpreadsheetId id,
+                                             final Set<SpreadsheetCell> cells) {
+        return new SpreadsheetDeltaNonWindowed(id, cells);
+    }
+
+    private SpreadsheetDeltaNonWindowed(final SpreadsheetId id,
+                                        final Set<SpreadsheetCell> cells) {
+        super(id, cells);
+    }
+
+    @Override
+    public SpreadsheetDelta setCells(final Set<SpreadsheetCell> cells) {
+        checkCells(cells);
+
+        final Set<SpreadsheetCell> copy = copyCells(cells);
+        return this.cells.equals(copy) ?
+                this :
+                new SpreadsheetDeltaNonWindowed(this.id, copy);
+    }
+
+    /**
+     * There is no window.
+     */
+    @Override
+    public List<Range<SpreadsheetCellReference>> window() {
+        return Lists.empty();
+    }
+
+    @Override
+    boolean canBeEquals(final Object other) {
+        return other instanceof SpreadsheetDeltaNonWindowed;
+    }
+
+    @Override
+    boolean equals1(final SpreadsheetDelta other) {
+        return other instanceof SpreadsheetDeltaNonWindowed;
+    }
+
+    @Override
+    public JsonNode toJsonNode() {
+        return this.toJsonNodeIdAndCells();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetDeltaWindowed.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetDeltaWindowed.java
@@ -1,0 +1,84 @@
+package walkingkooka.spreadsheet;
+
+import walkingkooka.compare.Range;
+import walkingkooka.compare.RangeBound;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetParsers;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.JsonStringNode;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link SpreadsheetDelta} with a non empty window.
+ */
+final class SpreadsheetDeltaWindowed extends SpreadsheetDelta {
+
+    /**
+     * Factory that creates a new {@link SpreadsheetDeltaWindowed} without checking, copying or filtering the cells.
+     */
+    static SpreadsheetDeltaWindowed with0(final SpreadsheetId id,
+                                          final Set<SpreadsheetCell> cells,
+                                          final List<Range<SpreadsheetCellReference>> window) {
+        return new SpreadsheetDeltaWindowed(id, cells, window);
+    }
+
+    private SpreadsheetDeltaWindowed(final SpreadsheetId id,
+                                     final Set<SpreadsheetCell> cells,
+                                     final List<Range<SpreadsheetCellReference>> window) {
+        super(id, cells);
+        this.window = window;
+    }
+
+    @Override
+    public SpreadsheetDelta setCells(final Set<SpreadsheetCell> cells) {
+        checkCells(cells);
+
+        final List<Range<SpreadsheetCellReference>> window = this.window;
+        final Set<SpreadsheetCell> filtered = filterCells(cells, window);
+        return this.cells.equals(filtered) ?
+                this :
+                new SpreadsheetDeltaWindowed(this.id, filtered, window);
+    }
+
+    @Override
+    public List<Range<SpreadsheetCellReference>> window() {
+        return this.window;
+    }
+
+    private final List<Range<SpreadsheetCellReference>> window;
+
+    @Override
+    boolean canBeEquals(final Object other) {
+        return other instanceof SpreadsheetDeltaWindowed;
+    }
+
+    @Override
+    boolean equals1(final SpreadsheetDelta other) {
+        return this.window.equals(other.window());
+    }
+
+    @Override
+    public JsonNode toJsonNode() {
+        return this.toJsonNodeIdAndCells()
+                .set(WINDOW_PROPERTY, this.windowToJsonNode());
+    }
+
+    private JsonStringNode windowToJsonNode() {
+        return JsonNode.string(this.window.stream()
+                .map(SpreadsheetDeltaWindowed::toStringRange)
+                .collect(Collectors.joining(WINDOW_SEPARATOR)));
+    }
+
+    private static String toStringRange(final Range<SpreadsheetCellReference> range) {
+        return toStringRangeBound(range.lowerBound())
+                .concat(SpreadsheetParsers.RANGE_SEPARATOR.string())
+                .concat(toStringRangeBound(range.upperBound()));
+    }
+
+    private static String toStringRangeBound(final RangeBound<SpreadsheetCellReference> bound) {
+        return bound.value().map(Object::toString).orElse("");
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaNonWindowedTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaNonWindowedTest.java
@@ -1,0 +1,85 @@
+package walkingkooka.spreadsheet;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
+import walkingkooka.compare.Range;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.tree.json.HasJsonNode;
+import walkingkooka.tree.json.JsonNode;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class SpreadsheetDeltaNonWindowedTest extends SpreadsheetDeltaTestCase2<SpreadsheetDeltaNonWindowed> {
+
+    @Test
+    public final void testCellsReadOnly() {
+        final SpreadsheetDelta delta = SpreadsheetDelta.with(this.id(), this.cells());
+        final Set<SpreadsheetCell> cells = delta.cells();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            cells.add(this.a1());
+        });
+
+        this.checkCells(delta, this.cells());
+    }
+
+    @Test
+    public void testSetDifferentCells() {
+        final SpreadsheetDeltaNonWindowed delta = this.createSpreadsheetDelta();
+        final Set<SpreadsheetCell> cells = this.cells0("B2", "C3");
+        final SpreadsheetDelta different = delta.setCells(cells);
+        this.checkId(different);
+        this.checkCells(different, cells);
+
+        this.checkId(delta);
+        this.checkCells(delta);
+    }
+
+    @Test
+    public void testEqualsSpreadsheetDeltaWindowed() {
+        this.checkNotEquals(SpreadsheetDeltaWindowed.with0(this.id(), this.cells(), this.window0("A1:Z99")));
+    }
+
+    @Test
+    public void testToString() {
+        final SpreadsheetId id = this.id();
+        this.toStringAndCheck(SpreadsheetDelta.with(id, this.cells()), "cells: A1=1, B2=2, C3=3");
+    }
+
+    // HasJson....................................................................................................
+
+    @Test
+    public void testFromJson() {
+        this.fromJsonNodeAndCheck(JsonNode.object()
+                        .set(SpreadsheetDelta.ID_PROPERTY, this.id().toJsonNode())
+                        .set(SpreadsheetDelta.CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells())),
+                this.createHasJsonNode());
+    }
+
+    @Test
+    public void testToJsonNode() {
+        this.toJsonNodeAndCheck(this.createHasJsonNode(),
+                JsonNode.object()
+                        .set(SpreadsheetDelta.ID_PROPERTY, this.id().toJsonNode())
+                        .set(SpreadsheetDelta.CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells())));
+    }
+
+    @Override
+    public Class<SpreadsheetDeltaNonWindowed> type() {
+        return SpreadsheetDeltaNonWindowed.class;
+    }
+
+    @Override
+    SpreadsheetDeltaNonWindowed createSpreadsheetDelta(final SpreadsheetId id,
+                                                       final Set<SpreadsheetCell> cells) {
+        return SpreadsheetDeltaNonWindowed.with0(id, cells);
+    }
+
+    @Override
+    List<Range<SpreadsheetCellReference>> window() {
+        return Lists.empty();
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTest.java
@@ -1,27 +1,13 @@
 package walkingkooka.spreadsheet;
 
 import org.junit.jupiter.api.Test;
-import walkingkooka.collect.set.Sets;
-import walkingkooka.spreadsheet.style.SpreadsheetCellStyle;
-import walkingkooka.test.ClassTesting2;
-import walkingkooka.test.HashCodeEqualsDefinedTesting;
-import walkingkooka.test.ToStringTesting;
-import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
-import walkingkooka.tree.json.HasJsonNode;
-import walkingkooka.tree.json.HasJsonNodeTesting;
-import walkingkooka.tree.json.JsonNode;
-import walkingkooka.tree.json.JsonNodeName;
 import walkingkooka.type.MemberVisibility;
 
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelta>,
-        HashCodeEqualsDefinedTesting<SpreadsheetDelta>,
-        HasJsonNodeTesting<SpreadsheetDelta>,
-        ToStringTesting<SpreadsheetDelta> {
+public final class SpreadsheetDeltaTest extends SpreadsheetDeltaTestCase<SpreadsheetDelta> {
 
     @Test
     public void testWithNullIdFails() {
@@ -46,78 +32,7 @@ public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelt
         this.checkCells(delta, cells);
     }
 
-    @Test
-    public void testCellsReadOnly() {
-        final SpreadsheetDelta delta = SpreadsheetDelta.with(this.id(), cells());
-        final Set<SpreadsheetCell> cells = delta.cells();
-
-        assertThrows(UnsupportedOperationException.class, () -> {
-            cells.clear();
-        });
-
-        this.checkCells(delta, this.cells());
-    }
-
-    // equals....................................................................................................
-
-    @Test
-    public void testDifferentId() {
-        this.checkNotEquals(SpreadsheetDelta.with(this.id(), Sets.of(this.cell("A99", "99"))));
-    }
-
-    @Test
-    public void testDifferentCells() {
-        this.checkNotEquals(SpreadsheetDelta.with(SpreadsheetId.with(999), this.cells()));
-    }
-
-    // HasJson....................................................................................................
-
-    @Test
-    public void testFromJsonMissingIdFails() {
-        this.fromJsonNodeFails(JsonNode.object()
-                .set(SpreadsheetDelta.CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells())));
-    }
-
-    @Test
-    public void testFromJsonMissingCellsFails() {
-        this.fromJsonNodeFails(JsonNode.object()
-                .set(SpreadsheetDelta.ID_PROPERTY, this.id().toJsonNode()));
-    }
-
-    @Test
-    public void testFromJsonUnknownPropertyFails() {
-        this.fromJsonNodeFails(JsonNode.object()
-                .set(SpreadsheetDelta.ID_PROPERTY, this.id().toJsonNode())
-                .set(SpreadsheetDelta.CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells()))
-                .set(JsonNodeName.with("unknown"), JsonNode.booleanNode(true)));
-    }
-
-    @Test
-    public void testFromJson() {
-        this.fromJsonNodeAndCheck(JsonNode.object()
-                        .set(SpreadsheetDelta.ID_PROPERTY, this.id().toJsonNode())
-                        .set(SpreadsheetDelta.CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells())),
-                this.createHasJsonNode());
-    }
-
-    @Test
-    public void testToJsonNode() {
-        this.toJsonNodeAndCheck(this.createHasJsonNode(),
-                JsonNode.object()
-                        .set(SpreadsheetDelta.ID_PROPERTY, this.id().toJsonNode())
-                        .set(SpreadsheetDelta.CELLS_PROPERTY, HasJsonNode.toJsonNodeSet(this.cells())));
-    }
-
-    // toString....................................................................................................
-
-    @Test
-    public void testToString() {
-        final SpreadsheetId id = this.id();
-        final Set<SpreadsheetCell> cells = this.cells();
-        this.toStringAndCheck(SpreadsheetDelta.with(id, cells), "" + cells);
-    }
-
-    // ClassTesting...............................................................................................
+    // ClassTesting..........................................................................................
 
     @Override
     public Class<SpreadsheetDelta> type() {
@@ -127,48 +42,5 @@ public final class SpreadsheetDeltaTest implements ClassTesting2<SpreadsheetDelt
     @Override
     public MemberVisibility typeVisibility() {
         return MemberVisibility.PUBLIC;
-    }
-
-    // HashCodeDefinedTesting...............................................................................................
-
-    @Override
-    public SpreadsheetDelta createObject() {
-        return this.createHasJsonNode();
-    }
-
-    // HasJsonTesting...............................................................................................
-
-    @Override
-    public SpreadsheetDelta createHasJsonNode() {
-        return SpreadsheetDelta.with(this.id(), this.cells());
-    }
-
-    // helpers...............................................................................................
-
-    private SpreadsheetId id() {
-        return SpreadsheetId.with(1234L);
-    }
-
-    private Set<SpreadsheetCell> cells() {
-        return Sets.of(this.cell("A1", "1+2"));
-    }
-
-    private SpreadsheetCell cell(final String cellReference, final String formulaText) {
-        return SpreadsheetCell.with(SpreadsheetCellReference.parse(cellReference),
-                SpreadsheetFormula.with(formulaText),
-                SpreadsheetCellStyle.EMPTY);
-    }
-
-    private void checkId(final SpreadsheetDelta delta, final SpreadsheetId id) {
-        assertEquals(id, delta.id(), "id");
-    }
-
-    private void checkCells(final SpreadsheetDelta delta, final Set<SpreadsheetCell> cells) {
-        assertEquals(cells, delta.cells(), "cells");
-    }
-
-    @Override
-    public SpreadsheetDelta fromJsonNode(final JsonNode jsonNode) {
-        return SpreadsheetDelta.fromJsonNode(jsonNode);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTestCase.java
@@ -1,0 +1,69 @@
+package walkingkooka.spreadsheet;
+
+import walkingkooka.collect.set.Sets;
+import walkingkooka.spreadsheet.style.SpreadsheetCellStyle;
+import walkingkooka.test.ClassTesting2;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class SpreadsheetDeltaTestCase<D extends SpreadsheetDelta> implements ClassTesting2<D> {
+
+    SpreadsheetDeltaTestCase() {
+        super();
+    }
+
+    // helpers...............................................................................................
+
+    final SpreadsheetId id() {
+        return SpreadsheetId.with(1234L);
+    }
+
+    final Set<SpreadsheetCell> cells() {
+        return Sets.of(this.a1(), this.b2(), this.c3());
+    }
+
+    final Set<SpreadsheetCell> cells0(final String... cellReferences) {
+        return Arrays.stream(cellReferences)
+                .map(r -> this.cell(r, "55"))
+                .collect(Collectors.toSet());
+    }
+
+    final SpreadsheetCell a1() {
+        return this.cell("A1", "1");
+    }
+
+    final SpreadsheetCell b2() {
+        return this.cell("B2", "2");
+    }
+
+    final SpreadsheetCell c3() {
+        return this.cell("C3", "3");
+    }
+
+    final SpreadsheetCell cell(final String cellReference, final String formulaText) {
+        return SpreadsheetCell.with(SpreadsheetCellReference.parse(cellReference),
+                SpreadsheetFormula.with(formulaText),
+                SpreadsheetCellStyle.EMPTY);
+    }
+
+    final void checkId(final SpreadsheetDelta delta) {
+        this.checkId(delta, this.id());
+    }
+
+    final void checkId(final SpreadsheetDelta delta, final SpreadsheetId id) {
+        assertEquals(id, delta.id(), "id");
+    }
+
+    final void checkCells(final SpreadsheetDelta delta) {
+        this.checkCells(delta, this.cells());
+    }
+
+    final void checkCells(final SpreadsheetDelta delta, final Set<SpreadsheetCell> cells) {
+        assertEquals(cells, delta.cells(), "cells");
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTestCase2.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTestCase2.java
@@ -1,0 +1,162 @@
+package walkingkooka.spreadsheet;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.Cast;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.compare.Range;
+import walkingkooka.test.HashCodeEqualsDefinedTesting;
+import walkingkooka.test.ToStringTesting;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.tree.json.HasJsonNodeTesting;
+import walkingkooka.tree.json.JsonNode;
+import walkingkooka.type.MemberVisibility;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public abstract class SpreadsheetDeltaTestCase2<D extends SpreadsheetDelta> extends SpreadsheetDeltaTestCase<D>
+        implements HashCodeEqualsDefinedTesting<D>,
+        HasJsonNodeTesting<D>,
+        ToStringTesting<D> {
+
+    SpreadsheetDeltaTestCase2() {
+        super();
+    }
+
+    @Test
+    public final void testWindowReadOnly() {
+        final SpreadsheetDelta delta = SpreadsheetDelta.with(this.id(), this.cells())
+                .setWindow(this.window());
+        final List<Range<SpreadsheetCellReference>> window = delta.window();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            window.add(Range.singleton(SpreadsheetCellReference.parse("Z99")));
+        });
+
+        this.checkWindow(delta, this.window());
+    }
+
+    @Test
+    public final void testSetCellsSame() {
+        final D delta = this.createSpreadsheetDelta();
+        assertSame(delta, delta.setCells(this.cells()));
+    }
+
+    @Test
+    public final void testSetWindowsSame() {
+        final D delta = this.createSpreadsheetDelta();
+        assertSame(delta, delta.setWindow(this.window()));
+    }
+
+    @Test
+    public final void testSetDifferentWindow() {
+        final D delta = this.createSpreadsheetDelta();
+
+        final List<Range<SpreadsheetCellReference>> window = this.window0("A1:Z9999");
+        assertNotEquals(window, this.window());
+
+        final SpreadsheetDelta different = delta.setWindow(window);
+
+        this.checkId(different);
+        this.checkCells(different);
+        this.checkWindow(different, window);
+
+        this.checkId(delta);
+        this.checkCells(delta);
+        this.checkWindow(delta);
+    }
+
+    @Test
+    public final void testSetDifferentWindowFilters() {
+        this.setDifferentWindowFilters("B1:Z99", "Z999:Z9999");
+    }
+
+    @Test
+    public final void testSetDifferentWindowFilters2() {
+        this.setDifferentWindowFilters("A99:A100", "B1:Z99");
+    }
+
+    private void setDifferentWindowFilters(final String range1, final String range2) {
+        final SpreadsheetDelta delta = this.createSpreadsheetDelta();
+
+        final List<Range<SpreadsheetCellReference>> window = this.window0(range1, range2);
+        final SpreadsheetDelta different = delta.setWindow(window);
+
+        this.checkId(different);
+        this.checkCells(different, Sets.of(this.b2(), this.c3()));
+        this.checkWindow(different, window);
+
+        this.checkId(delta);
+        this.checkCells(delta, Sets.of(this.a1(), this.b2(), this.c3()));
+        this.checkWindow(delta);
+    }
+
+    // equals....................................................................................................
+
+    @Test
+    public final void testDifferentId() {
+        this.checkNotEquals(this.createSpreadsheetDelta(this.id(), Sets.of(this.cell("A1", "99"))));
+    }
+
+    @Test
+    public final void testDifferentCells() {
+        this.checkNotEquals(this.createSpreadsheetDelta(SpreadsheetId.with(999), this.cells()));
+    }
+
+    final D createSpreadsheetDelta() {
+        return this.createSpreadsheetDelta(this.id(), this.cells());
+    }
+
+    abstract D createSpreadsheetDelta(final SpreadsheetId id, final Set<SpreadsheetCell> cells);
+
+    abstract List<Range<SpreadsheetCellReference>> window();
+
+    final List<Range<SpreadsheetCellReference>> window0(final String... range) {
+        return Arrays.stream(range)
+                .map(SpreadsheetCellReference::parseRange)
+                .collect(Collectors.toList());
+    }
+
+    final void checkWindow(final SpreadsheetDelta delta) {
+        this.checkWindow(delta, this.window());
+    }
+
+    final void checkWindow(final SpreadsheetDelta delta, final List<Range<SpreadsheetCellReference>> window) {
+        assertEquals(window, delta.window(), "window");
+    }
+
+    // ClassTesting...............................................................................................
+
+    @Override
+    public final MemberVisibility typeVisibility() {
+        return MemberVisibility.PACKAGE_PRIVATE;
+    }
+
+    // HashCodeDefinedTesting...............................................................................................
+
+    @Override
+    public final D createObject() {
+        return this.createSpreadsheetDelta();
+    }
+
+    // HasJsonTesting...............................................................................................
+
+    @Override
+    public final D createHasJsonNode() {
+        return this.createSpreadsheetDelta();
+    }
+
+    // helpers...............................................................................................
+
+    @Override
+    public final D fromJsonNode(final JsonNode jsonNode) {
+        return Cast.to(SpreadsheetDelta.fromJsonNode(jsonNode));
+    }
+}

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaWindowedTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaWindowedTest.java
@@ -1,0 +1,84 @@
+package walkingkooka.spreadsheet;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.collect.set.Sets;
+import walkingkooka.compare.Range;
+import walkingkooka.text.cursor.parser.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.tree.json.JsonNode;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class SpreadsheetDeltaWindowedTest extends SpreadsheetDeltaTestCase2<SpreadsheetDeltaWindowed> {
+
+    @Test
+    public final void testCellsReadOnly() {
+        final SpreadsheetDelta delta = SpreadsheetDelta.with(this.id(), this.cells())
+                .setCells(this.cells());
+        final Set<SpreadsheetCell> cells = delta.cells();
+
+        assertThrows(UnsupportedOperationException.class, () -> {
+            cells.add(this.a1());
+        });
+
+        this.checkCells(delta, this.cells());
+    }
+
+    @Test
+    public void testSetCellsFiltered() {
+        final SpreadsheetDelta delta = this.createSpreadsheetDelta();
+
+        final Set<SpreadsheetCell> cells = Sets.of(this.a1(), this.b2(), this.cell("E99", "should be removed!"));
+        final SpreadsheetDelta different = delta.setCells(cells);
+
+        this.checkId(different);
+        this.checkCells(different, Sets.of(this.a1(), this.b2()));
+        this.checkWindow(different);
+
+        this.checkId(delta);
+        this.checkCells(delta, this.cells());
+        this.checkWindow(delta);
+    }
+
+    @Test
+    public void testEqualsSpreadsheetDeltaNonWindowed() {
+        this.checkNotEquals(SpreadsheetDeltaNonWindowed.with0(this.id(), this.cells()));
+    }
+
+    @Test
+    public void testEqualsDifferentWindow() {
+        this.checkNotEquals(SpreadsheetDeltaWindowed.with0(this.id(), this.cells(), this.window0("A1:E9999")));
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.createSpreadsheetDelta(), "cells: A1=1, B2=2, C3=3 window: (A1..E5),(F6..Z99)");
+    }
+
+    @Test
+    public void testToJsonNode() {
+        final SpreadsheetDelta delta = this.createSpreadsheetDelta();
+        final JsonNode node = delta.toJsonNode();
+        assertEquals(JsonNode.string("A1:E5,F6:Z99"),
+                node.objectOrFail().getOrFail(SpreadsheetDelta.WINDOW_PROPERTY).removeParent(),
+                () -> " window property incorrect " + node);
+    }
+
+    @Override
+    public Class<SpreadsheetDeltaWindowed> type() {
+        return SpreadsheetDeltaWindowed.class;
+    }
+
+    @Override
+    SpreadsheetDeltaWindowed createSpreadsheetDelta(final SpreadsheetId id, final Set<SpreadsheetCell> cells) {
+        return SpreadsheetDeltaWindowed.with0(id, cells, this.window());
+    }
+
+    @Override
+    List<Range<SpreadsheetCellReference>> window() {
+        return this.window0("A1:E5", "F6:Z99");
+    }
+}


### PR DESCRIPTION
- The window property is used to filter cells belonging to a SpreadsheetDelta.
- TODO update hatoes handlers to accept SpreadsheetDelta which may have window property and use.