### PR TITLE
SpreadsheetRange extends SpreadsheetExpressionReference.

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/FakeSpreadsheetExpressionReferenceVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/FakeSpreadsheetExpressionReferenceVisitor.java
@@ -38,6 +38,16 @@ public class FakeSpreadsheetExpressionReferenceVisitor extends SpreadsheetExpres
     }
 
     @Override
+    protected Visiting startVisit(final SpreadsheetExpressionReference reference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void endVisit(final SpreadsheetExpressionReference reference) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     protected void visit(final SpreadsheetCellReference reference) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetCellReference.java
@@ -200,6 +200,18 @@ public final class SpreadsheetCellReference extends SpreadsheetExpressionReferen
         return false;
     }
 
+    @Override
+    public boolean isRange() {
+        return false;
+    }
+
+    // SpreadsheetExpressionReferenceVisitor............................................................................
+
+    @Override
+    void accept(final SpreadsheetExpressionReferenceVisitor visitor) {
+        visitor.visit(this);
+    }
+
     // HashCodeEqualsDefined............................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetDelta.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetDelta.java
@@ -194,7 +194,7 @@ public abstract class SpreadsheetDelta implements HashCodeEqualsDefined, HateosR
 
     private static List<SpreadsheetRange> windowFromJsonNode(final String range) {
         return Arrays.stream(range.split(WINDOW_SEPARATOR))
-                .map(SpreadsheetRange::parse)
+                .map(SpreadsheetRange::parseRange)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetExpressionReference.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetExpressionReference.java
@@ -138,6 +138,13 @@ abstract public class SpreadsheetExpressionReference implements ExpressionRefere
     }
 
     /**
+     * Parsers the text expecting a valid {@link SpreadsheetRange} or fails.
+     */
+    public static SpreadsheetRange parseRange(final String text) {
+        return SpreadsheetRange.parseRange0(text);
+    }
+
+    /**
      * Package private to limit sub classing.
      */
     SpreadsheetExpressionReference() {
@@ -155,6 +162,15 @@ abstract public class SpreadsheetExpressionReference implements ExpressionRefere
      * Only {@link SpreadsheetLabelName} returns true.
      */
     public abstract boolean isLabelName();
+
+    /**
+     * Only {@link SpreadsheetRange} returns true.
+     */
+    public abstract boolean isRange();
+
+    // SpreadsheetExpressionReferenceVisitor............................................................................
+
+    abstract void accept(final SpreadsheetExpressionReferenceVisitor visitor);
 
     // Object...........................................................................................................
 
@@ -212,6 +228,13 @@ abstract public class SpreadsheetExpressionReference implements ExpressionRefere
     }
 
     /**
+     * Accepts a json string and returns a {@link SpreadsheetRange} or fails.
+     */
+    public static SpreadsheetRange fromJsonNodeRange(final JsonNode node) {
+        return fromJsonNode0(node, SpreadsheetExpressionReference::parseRange);
+    }
+
+    /**
      * Generic helper that tries to convert the node into a string and call a parse method.
      */
     private static <R extends SpreadsheetExpressionReference> R fromJsonNode0(final JsonNode node,
@@ -240,5 +263,8 @@ abstract public class SpreadsheetExpressionReference implements ExpressionRefere
         HasJsonNode.register("spreadsheet-label-name",
                 SpreadsheetLabelName::fromJsonNodeLabelName,
                 SpreadsheetLabelName.class);
+        HasJsonNode.register("spreadsheet-range",
+                SpreadsheetRange::fromJsonNodeRange,
+                SpreadsheetRange.class);
     }
 }

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceVisitor.java
@@ -17,6 +17,7 @@
 
 package walkingkooka.spreadsheet;
 
+import walkingkooka.Cast;
 import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.visit.Visiting;
 import walkingkooka.tree.visit.Visitor;
@@ -24,7 +25,7 @@ import walkingkooka.tree.visit.Visitor;
 import java.util.Objects;
 
 /**
- * A {@link Visitor} for all known implementations of {@link ExpressionReference}.
+ * A {@link Visitor} for all known implementations of {@link SpreadsheetExpressionReference}.
  */
 public abstract class SpreadsheetExpressionReferenceVisitor extends Visitor<ExpressionReference> {
 
@@ -36,21 +37,11 @@ public abstract class SpreadsheetExpressionReferenceVisitor extends Visitor<Expr
         Objects.requireNonNull(reference, "reference");
 
         if (Visiting.CONTINUE == this.startVisit(reference)) {
-            do {
-                if (reference instanceof SpreadsheetCellReference) {
-                    this.visit(SpreadsheetCellReference.class.cast(reference));
-                    break;
-                }
-                if (reference instanceof SpreadsheetLabelName) {
-                    this.visit(SpreadsheetLabelName.class.cast(reference));
-                    break;
-                }
-                if (reference instanceof SpreadsheetRange) {
-                    this.visit(SpreadsheetRange.class.cast(reference));
-                    break;
-                }
+
+            if (false == reference instanceof SpreadsheetExpressionReference) {
                 throw new IllegalArgumentException("Unknown reference type: " + reference.getClass().getName() + "=" + reference);
-            } while (false);
+            }
+            this.traverse(Cast.to(reference));
         }
         this.endVisit(reference);
     }
@@ -60,6 +51,21 @@ public abstract class SpreadsheetExpressionReferenceVisitor extends Visitor<Expr
     }
 
     protected void endVisit(final ExpressionReference reference) {
+        // nop
+    }
+
+    private void traverse(final SpreadsheetExpressionReference reference) {
+        if (Visiting.CONTINUE == this.startVisit(reference)) {
+            reference.accept(this);
+        }
+        this.endVisit(reference);
+    }
+
+    protected Visiting startVisit(final SpreadsheetExpressionReference reference) {
+        return Visiting.CONTINUE;
+    }
+
+    protected void endVisit(final SpreadsheetExpressionReference reference) {
         // nop
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceVisitorTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceVisitorTesting.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.spreadsheet;
+
+import walkingkooka.tree.expression.ExpressionReference;
+import walkingkooka.tree.visit.VisitorTesting;
+
+/**
+ * A mixin interface with tests and helpers to assist in testing a {@link SpreadsheetExpressionReferenceVisitor}
+ */
+public interface SpreadsheetExpressionReferenceVisitorTesting<V extends SpreadsheetExpressionReferenceVisitor> extends VisitorTesting<V, ExpressionReference> {
+
+    @Override
+    default String typeNameSuffix() {
+        return SpreadsheetExpressionReferenceVisitor.class.getSimpleName();
+    }
+}

--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetLabelName.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetLabelName.java
@@ -93,6 +93,18 @@ final public class SpreadsheetLabelName extends SpreadsheetExpressionReference i
         return true;
     }
 
+    @Override
+    public boolean isRange() {
+        return false;
+    }
+
+    // SpreadsheetExpressionReferenceVisitor............................................................................
+
+    @Override
+    void accept(final SpreadsheetExpressionReferenceVisitor visitor) {
+        visitor.visit(this);
+    }
+
     // Comparable........................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineCopyCells.java
+++ b/src/main/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineCopyCells.java
@@ -44,7 +44,7 @@ final class BasicSpreadsheetEngineCopyCells {
 
     private void execute(final Collection<SpreadsheetCell> from,
                          final SpreadsheetRange to) {
-        final SpreadsheetRange fromRange = SpreadsheetRange.from(from.stream()
+        final SpreadsheetRange fromRange = SpreadsheetRange.fromCells(from.stream()
                 .map(c -> c.reference())
                 .collect(Collectors.toList()));
 

--- a/src/main/java/walkingkooka/spreadsheet/hateos/SpreadsheetEngineCopyCellsHateosHandler.java
+++ b/src/main/java/walkingkooka/spreadsheet/hateos/SpreadsheetEngineCopyCellsHateosHandler.java
@@ -23,6 +23,7 @@ import walkingkooka.net.http.server.HttpRequestAttribute;
 import walkingkooka.net.http.server.hateos.HateosHandler;
 import walkingkooka.spreadsheet.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.SpreadsheetDelta;
+import walkingkooka.spreadsheet.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.SpreadsheetRange;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngine;
 import walkingkooka.spreadsheet.engine.SpreadsheetEngineContext;
@@ -70,7 +71,7 @@ final class SpreadsheetEngineCopyCellsHateosHandler extends SpreadsheetEngineHat
                                        final SpreadsheetDelta resource,
                                        final Map<HttpRequestAttribute<?>, Object> parameters) {
         return this.engine.copyCells(resource.cells(),
-                this.parameterValueOrFail(parameters, TO, SpreadsheetRange::parse),
+                this.parameterValueOrFail(parameters, TO, SpreadsheetExpressionReference::parseRange),
                 this.context.get());
     }
 

--- a/src/main/java/walkingkooka/spreadsheet/store/range/SpreadsheetRangeStoreTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/store/range/SpreadsheetRangeStoreTesting.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.SpreadsheetRange;
 import walkingkooka.spreadsheet.SpreadsheetReferenceKind;
 import walkingkooka.spreadsheet.store.StoreTesting;
@@ -262,7 +263,7 @@ public interface SpreadsheetRangeStoreTesting<S extends SpreadsheetRangeStore<V>
 
     @Override
     default SpreadsheetRange id() {
-        return SpreadsheetRange.parse("A1:B2");
+        return SpreadsheetExpressionReference.parseRange("A1:B2");
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetCellReferenceTest.java
@@ -22,7 +22,9 @@ import walkingkooka.compare.ComparableTesting;
 import walkingkooka.compare.LowerOrUpperTesting;
 import walkingkooka.compare.Range;
 import walkingkooka.test.ParseStringTesting;
+import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.visit.Visiting;
 import walkingkooka.type.JavaVisibility;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -477,6 +479,49 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetExpressionRef
                 SpreadsheetExpressionReference.parseCellReference("$A$1"));
     }
 
+    // SpreadsheetExpressionReferenceVisitor.............................................................................
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final SpreadsheetCellReference reference = this.createReference();
+
+        new FakeSpreadsheetExpressionReferenceVisitor() {
+            @Override
+            protected Visiting startVisit(final ExpressionReference r) {
+                assertSame(reference, r);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ExpressionReference r) {
+                assertSame(reference, r);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final SpreadsheetExpressionReference r) {
+                assertSame(reference, r);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final SpreadsheetExpressionReference r) {
+                assertSame(reference, r);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final SpreadsheetCellReference r) {
+                assertSame(reference, r);
+                b.append("5");
+            }
+        }.accept(reference);
+        assertEquals("13542", b.toString());
+    }
+
     // toString..................................................................................................
 
     @Test
@@ -543,7 +588,6 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetExpressionRef
     }
 
     // ParseStringTesting.........................................................................................
-
 
     @Override
     public SpreadsheetCellReference parse(final String text) {

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTestCase2.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetDeltaTestCase2.java
@@ -20,7 +20,6 @@ package walkingkooka.spreadsheet;
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.set.Sets;
-import walkingkooka.compare.Range;
 import walkingkooka.test.HashCodeEqualsDefinedTesting;
 import walkingkooka.test.ToStringTesting;
 import walkingkooka.tree.json.HasJsonNodeTesting;
@@ -53,7 +52,7 @@ public abstract class SpreadsheetDeltaTestCase2<D extends SpreadsheetDelta> exte
         final List<SpreadsheetRange> window = delta.window();
 
         assertThrows(UnsupportedOperationException.class, () -> {
-            window.add(SpreadsheetRange.parse("A1:A2"));
+            window.add(SpreadsheetRange.parseRange("A1:A2"));
         });
 
         this.checkWindow(delta, this.window());
@@ -136,7 +135,7 @@ public abstract class SpreadsheetDeltaTestCase2<D extends SpreadsheetDelta> exte
 
     final List<SpreadsheetRange> window0(final String... range) {
         return Arrays.stream(range)
-                .map(SpreadsheetRange::parse)
+                .map(SpreadsheetRange::parseRange)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceTestCase.java
@@ -20,6 +20,7 @@ package walkingkooka.spreadsheet;
 import org.junit.jupiter.api.Test;
 import walkingkooka.predicate.Predicates;
 import walkingkooka.test.ClassTesting2;
+import walkingkooka.test.HashCodeEqualsDefinedTesting;
 import walkingkooka.test.IsMethodTesting;
 import walkingkooka.test.ToStringTesting;
 import walkingkooka.tree.expression.ExpressionReference;
@@ -29,6 +30,7 @@ import walkingkooka.tree.json.JsonNode;
 import java.util.function.Predicate;
 
 public abstract class SpreadsheetExpressionReferenceTestCase<R extends SpreadsheetExpressionReference> implements ClassTesting2<R>,
+        HashCodeEqualsDefinedTesting<R>,
         HasJsonNodeTesting<R>,
         IsMethodTesting<R>,
         ToStringTesting<R> {
@@ -44,6 +46,13 @@ public abstract class SpreadsheetExpressionReferenceTestCase<R extends Spreadshe
     }
 
     abstract R createReference();
+
+    // HashCodeEqualsDefinedTesting.....................................................................................
+
+    @Override
+    public final R createObject() {
+        return this.createReference();
+    }
 
     // HasJsonNode......................................................................................................
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceVisitorTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetExpressionReferenceVisitorTest.java
@@ -30,117 +30,62 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 public final class SpreadsheetExpressionReferenceVisitorTest implements VisitorTesting<SpreadsheetExpressionReferenceVisitor, ExpressionReference> {
 
     @Test
-    public void testStartVisitSkip() {
+    public void testStartVisitExpressionReferenceSkip() {
         final StringBuilder b = new StringBuilder();
 
-        final SpreadsheetCellReference label = SpreadsheetExpressionReference.parseCellReference("A1");
+        final SpreadsheetCellReference cell = SpreadsheetExpressionReference.parseCellReference("A1");
         new FakeSpreadsheetExpressionReferenceVisitor() {
             @Override
             protected Visiting startVisit(final ExpressionReference reference) {
-                assertSame(label, reference);
+                assertSame(cell, reference);
                 b.append("1");
                 return Visiting.SKIP;
             }
 
             @Override
             protected void endVisit(final ExpressionReference reference) {
-                assertSame(label, reference);
+                assertSame(cell, reference);
                 b.append("2");
             }
-        }.accept(label);
+        }.accept(cell);
 
         assertEquals("12", b.toString());
     }
 
     @Test
-    public void testAcceptSpreadsheetCellReference() {
+    public void testStartVisitSpreadsheetExpressionReferenceSkip() {
         final StringBuilder b = new StringBuilder();
 
-        final SpreadsheetCellReference label = SpreadsheetExpressionReference.parseCellReference("A1");
+        final SpreadsheetCellReference cell = SpreadsheetExpressionReference.parseCellReference("A1");
         new FakeSpreadsheetExpressionReferenceVisitor() {
             @Override
             protected Visiting startVisit(final ExpressionReference reference) {
-                assertSame(label, reference);
+                assertSame(cell, reference);
                 b.append("1");
                 return Visiting.CONTINUE;
             }
 
             @Override
             protected void endVisit(final ExpressionReference reference) {
-                assertSame(label, reference);
+                assertSame(cell, reference);
                 b.append("2");
             }
 
             @Override
-            protected void visit(final SpreadsheetCellReference l) {
-                assertSame(label, l);
+            protected Visiting startVisit(final SpreadsheetExpressionReference reference) {
+                assertSame(cell, reference);
                 b.append("3");
-            }
-
-        }.accept(label);
-
-        assertEquals("132", b.toString());
-    }
-
-    @Test
-    public void testAcceptSpreadsheetLabelName() {
-        final StringBuilder b = new StringBuilder();
-
-        final SpreadsheetLabelName label = SpreadsheetExpressionReference.labelName("label");
-        new FakeSpreadsheetExpressionReferenceVisitor() {
-            @Override
-            protected Visiting startVisit(final ExpressionReference reference) {
-                assertSame(label, reference);
-                b.append("1");
-                return Visiting.CONTINUE;
+                return Visiting.SKIP;
             }
 
             @Override
-            protected void endVisit(final ExpressionReference reference) {
-                assertSame(label, reference);
-                b.append("2");
+            protected void endVisit(final SpreadsheetExpressionReference reference) {
+                assertSame(cell, reference);
+                b.append("4");
             }
+        }.accept(cell);
 
-            @Override
-            protected void visit(final SpreadsheetLabelName l) {
-                assertSame(label, l);
-                b.append("3");
-            }
-
-        }.accept(label);
-
-        assertEquals("132", b.toString());
-    }
-
-    @Test
-    public void testAcceptSpreadsheetRange() {
-        final StringBuilder b = new StringBuilder();
-
-        final SpreadsheetRange range = SpreadsheetRange.parse("A1:B2");
-
-        new FakeSpreadsheetExpressionReferenceVisitor() {
-            @Override
-            protected Visiting startVisit(final ExpressionReference reference) {
-                assertSame(range, reference);
-                b.append("1");
-                return Visiting.CONTINUE;
-            }
-
-            @Override
-            protected void endVisit(final ExpressionReference reference) {
-                assertSame(range, reference);
-                b.append("2");
-            }
-
-            @Override
-            protected void visit(final SpreadsheetRange r) {
-                assertSame(range, r);
-                b.append("3");
-            }
-
-        }.accept(range);
-
-        assertEquals("132", b.toString());
+        assertEquals("1342", b.toString());
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetLabelNameTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetLabelNameTest.java
@@ -22,9 +22,13 @@ import walkingkooka.InvalidCharacterException;
 import walkingkooka.naming.NameTesting;
 import walkingkooka.naming.PropertiesPath;
 import walkingkooka.text.CaseSensitivity;
+import walkingkooka.tree.expression.ExpressionReference;
 import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.visit.Visiting;
 import walkingkooka.type.JavaVisibility;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 final public class SpreadsheetLabelNameTest extends SpreadsheetExpressionReferenceTestCase<SpreadsheetLabelName>
@@ -108,6 +112,49 @@ final public class SpreadsheetLabelNameTest extends SpreadsheetExpressionReferen
     @Test
     public void testWithEnormousRow() {
         this.createNameAndCheck("A" + (SpreadsheetRowReference.MAX + 1));
+    }
+
+    // SpreadsheetExpressionReferenceVisitor.............................................................................
+
+    @Test
+    public void testAccept() {
+        final StringBuilder b = new StringBuilder();
+        final SpreadsheetLabelName reference = this.createReference();
+
+        new FakeSpreadsheetExpressionReferenceVisitor() {
+            @Override
+            protected Visiting startVisit(final ExpressionReference r) {
+                assertSame(reference, r);
+                b.append("1");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final ExpressionReference r) {
+                assertSame(reference, r);
+                b.append("2");
+            }
+
+            @Override
+            protected Visiting startVisit(final SpreadsheetExpressionReference r) {
+                assertSame(reference, r);
+                b.append("3");
+                return Visiting.CONTINUE;
+            }
+
+            @Override
+            protected void endVisit(final SpreadsheetExpressionReference r) {
+                assertSame(reference, r);
+                b.append("4");
+            }
+
+            @Override
+            protected void visit(final SpreadsheetLabelName r) {
+                assertSame(reference, r);
+                b.append("5");
+            }
+        }.accept(reference);
+        assertEquals("13542", b.toString());
     }
 
     // HasJsonNode..................................................................................................

--- a/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/engine/BasicSpreadsheetEngineTest.java
@@ -539,7 +539,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
                           final TextStyle style,
                           final SpreadsheetCellReference cell,
                           final SpreadsheetRangeStore<SpreadsheetConditionalFormattingRule> rules) {
-        rules.addValue(SpreadsheetRange.cell(cell), rule(result, priority, style));
+        rules.addValue(cell.spreadsheetRange(cell), rule(result, priority, style));
     }
 
     private SpreadsheetConditionalFormattingRule rule(final boolean result,
@@ -3734,7 +3734,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
         this.copyCellsAndCheck(engine,
                 Lists.of(cellA),
-                SpreadsheetRange.cell(d),
+                d.spreadsheetRange(d),
                 context,
                 this.formattedCellWithValue(d, "1+0", BigDecimal.valueOf(1 + 0)));
 
@@ -3919,7 +3919,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
         this.copyCellsAndCheck(engine,
                 Lists.of(cellB),
-                SpreadsheetRange.cell(d),
+                d.spreadsheetRange(d),
                 context,
                 this.formattedCellWithValue(a, "1+0", BigDecimal.valueOf(1 + 0)),
                 this.formattedCellWithValue(d, "" + a, BigDecimal.valueOf(1 + 0)));
@@ -3941,7 +3941,7 @@ public final class BasicSpreadsheetEngineTest extends BasicSpreadsheetEngineTest
 
         this.copyCellsAndCheck(engine,
                 Lists.of(cellB, cellC),
-                SpreadsheetRange.parse("E5:F6"),
+                SpreadsheetExpressionReference.parseRange("E5:F6"),
                 context,
                 this.formattedCellWithValue("E5", "2", BigDecimal.valueOf(2 + 0)),
                 this.formattedCellWithValue("F6", "3+E5", BigDecimal.valueOf(3 + 2)));

--- a/src/test/java/walkingkooka/spreadsheet/hateos/SpreadsheetEngineCopyCellsHateosHandlerTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/hateos/SpreadsheetEngineCopyCellsHateosHandlerTest.java
@@ -85,7 +85,7 @@ public final class SpreadsheetEngineCopyCellsHateosHandlerTest extends
                                               final SpreadsheetRange to,
                                               final SpreadsheetEngineContext context) {
                 assertEquals(resource().get().cells(), from, "from");
-                assertEquals(SpreadsheetRange.parse(TO), to, "to");
+                assertEquals(SpreadsheetExpressionReference.parseRange(TO), to, "to");
                 return delta();
             }
         };

--- a/src/test/java/walkingkooka/spreadsheet/store/label/TreeMapSpreadsheetLabelStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/label/TreeMapSpreadsheetLabelStoreTest.java
@@ -125,7 +125,7 @@ public final class TreeMapSpreadsheetLabelStoreTest extends SpreadsheetLabelStor
     }
 
     private SpreadsheetRange range1() {
-        return SpreadsheetRange.parse("A1:A3");
+        return SpreadsheetExpressionReference.parseRange("A1:A3");
     }
 
     @Override

--- a/src/test/java/walkingkooka/spreadsheet/store/range/ReadOnlySpreadsheetRangeStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/range/ReadOnlySpreadsheetRangeStoreTest.java
@@ -19,7 +19,6 @@ package walkingkooka.spreadsheet.store.range;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
-import walkingkooka.spreadsheet.SpreadsheetCellReference;
 import walkingkooka.spreadsheet.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.SpreadsheetRange;
 import walkingkooka.spreadsheet.store.ReadOnlyStoreTesting;
@@ -31,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public final class ReadOnlySpreadsheetRangeStoreTest implements SpreadsheetRangeStoreTesting<ReadOnlySpreadsheetRangeStore<String>, String>,
         ReadOnlyStoreTesting<ReadOnlySpreadsheetRangeStore<String>, SpreadsheetRange, List<String>> {
 
-    private final static SpreadsheetRange RANGE = SpreadsheetRange.parse("a1:b2");
+    private final static SpreadsheetRange RANGE = SpreadsheetExpressionReference.parseRange("a1:b2");
     private final static String VALUE = "value";
 
     @Test

--- a/src/test/java/walkingkooka/spreadsheet/store/range/TreeMapSpreadsheetRangeStoreTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/store/range/TreeMapSpreadsheetRangeStoreTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.Cast;
 import walkingkooka.collect.list.Lists;
 import walkingkooka.spreadsheet.SpreadsheetCellReference;
+import walkingkooka.spreadsheet.SpreadsheetExpressionReference;
 import walkingkooka.spreadsheet.SpreadsheetRange;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -774,7 +775,7 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueUnknownValue() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
@@ -785,11 +786,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValue2() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         final String value2 = "value2";
         store.addValue(range2, value2);
 
@@ -801,7 +802,7 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueRemoveValue() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
         store.removeValue(range1, value1);
@@ -813,7 +814,7 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueRemoveValueAddValue() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
         store.removeValue(range1, value1);
@@ -828,7 +829,7 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueReplaceValue() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
@@ -843,8 +844,8 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueRemoveValue2() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
 
         final String value1 = "value1";
         store.addValue(range1, value1);
@@ -857,11 +858,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueManyRanges() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         store.addValue(range2, value1);
 
         this.rangesWithValuesAndCheck(store, value1, range1, range2);
@@ -872,11 +873,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueManyRanges2() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         store.addValue(range2, value1);
 
         final String value2 = "value2";
@@ -891,11 +892,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueReplaceValueManyRanges() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         final String value2 = "value2";
         store.addValue(range2, value2);
 
@@ -911,11 +912,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueReplaceValueManyRanges2() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         final String value2 = "value2";
         store.addValue(range2, value2);
 
@@ -935,11 +936,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testRangesWithValueAddValueRemoveValueManyRanges() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         final String value2 = "value2";
         store.addValue(range2, value2);
 
@@ -957,11 +958,11 @@ public final class TreeMapSpreadsheetRangeStoreTest extends TreeMapSpreadsheetRa
     public void testToString() {
         final TreeMapSpreadsheetRangeStore<String> store = this.createStore();
 
-        final SpreadsheetRange range1 = SpreadsheetRange.parse("A1:A1");
+        final SpreadsheetRange range1 = SpreadsheetExpressionReference.parseRange("A1:A1");
         final String value1 = "value1";
         store.addValue(range1, value1);
 
-        final SpreadsheetRange range2 = SpreadsheetRange.parse("A2:A2");
+        final SpreadsheetRange range2 = SpreadsheetExpressionReference.parseRange("A2:A2");
         final String value2 = "value2";
         store.addValue(range2, value2);
 


### PR DESCRIPTION
- SpreadsheetExpressionReference.range/parseRange public static methods.
- SpreadsheetExpressionReferenceVisitor: SpreadsheetExpressionReference double dispatch, replaces old instanceof tests.
- SpreadsheetExpressionReferenceVisitor: added startVisit(SpreadsheetExpressionReference) and endVisit(SpreadsheetExpressionReference)
- SpreadsheetExpressionReference.isRange() added.

Closes #289 