### PR TITLE
SpreadsheetId.parse/toString hex encoded

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/SpreadsheetId.java
+++ b/src/main/java/walkingkooka/spreadsheet/SpreadsheetId.java
@@ -21,6 +21,7 @@ import walkingkooka.Cast;
 import walkingkooka.Value;
 import walkingkooka.net.http.server.hateos.HateosResource;
 import walkingkooka.test.HashCodeEqualsDefined;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.json.HasJsonNode;
 import walkingkooka.tree.json.JsonNode;
 
@@ -33,6 +34,22 @@ public final class SpreadsheetId implements Comparable<SpreadsheetId>,
         HateosResource<Long>,
         Value<Long> {
 
+    /**
+     * Parses some text into a {@link SpreadsheetId}. This is the inverse of {@link SpreadsheetId#toString()}.
+     */
+    public static SpreadsheetId parse(final String text) {
+        CharSequences.failIfNullOrEmpty(text, "text");
+
+        try {
+            return new SpreadsheetId(Long.parseLong(text, 16));
+        } catch (final NumberFormatException cause) {
+            throw new IllegalArgumentException(cause.getMessage(), cause);
+        }
+    }
+
+    /**
+     * Creates a new {@link SpreadsheetId}
+     */
     public static SpreadsheetId with(final long value) {
         return new SpreadsheetId(value);
     }
@@ -108,6 +125,6 @@ public final class SpreadsheetId implements Comparable<SpreadsheetId>,
 
     @Override
     public String toString() {
-        return this.value.toString();
+        return Long.toHexString(this.value);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/MemorySpreadsheetContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/MemorySpreadsheetContextTest.java
@@ -434,12 +434,12 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 "    }\n" +
                 "  }],\n" +
                 "  \"_links\": [{\n" +
-                "    \"href\": \"http://example.com/api987/123/cell/123/copy\",\n" +
+                "    \"href\": \"http://example.com/api987/123/cell/7b/copy\",\n" +
                 "    \"method\": \"POST\",\n" +
                 "    \"rel\": \"copy\",\n" +
                 "    \"type\": \"application/hal+json\"\n" +
                 "  }, {\n" +
-                "    \"href\": \"http://example.com/api987/123/cell/123\",\n" +
+                "    \"href\": \"http://example.com/api987/123/cell/7b\",\n" +
                 "    \"method\": \"POST\",\n" +
                 "    \"rel\": \"self\",\n" +
                 "    \"type\": \"application/hal+json\"\n" +
@@ -447,7 +447,7 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 "}";
 
         expected.addEntity(HttpEntity.with(Maps.of(
-                HttpHeaderName.CONTENT_LENGTH, 789L,
+                HttpHeaderName.CONTENT_LENGTH, 787L,
                 HttpHeaderName.CONTENT_TYPE, HateosContentType.json().contentType().setCharset(CharsetName.UTF_8)),
                 Binary.with(expectedBody.getBytes(Charset.defaultCharset()))));
 

--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetIdTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetIdTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.compare.ComparableTesting;
 import walkingkooka.test.ClassTesting2;
 import walkingkooka.test.HashCodeEqualsDefinedTesting;
+import walkingkooka.test.ParseStringTesting;
 import walkingkooka.test.ToStringTesting;
 import walkingkooka.tree.json.HasJsonNodeTesting;
 import walkingkooka.tree.json.JsonNode;
@@ -33,6 +34,7 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
         ComparableTesting<SpreadsheetId>,
         HashCodeEqualsDefinedTesting<SpreadsheetId>,
         HasJsonNodeTesting<SpreadsheetId>,
+        ParseStringTesting<SpreadsheetId>,
         ToStringTesting<SpreadsheetId> {
 
     private final static Long VALUE = 123L;
@@ -42,6 +44,16 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
         final SpreadsheetId id = SpreadsheetId.with(VALUE);
         assertEquals(VALUE, id.value(), "value");
         assertEquals(VALUE, id.id(), "id");
+    }
+
+    @Test
+    public void testParseInvalidFails() {
+        this.parseFails("XYZ", IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testParse() {
+        this.parseAndCheck("1A", SpreadsheetId.with(0x1a));
     }
 
     @Test
@@ -67,7 +79,7 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
     @Test
     public void testToString() {
         this.toStringAndCheck(SpreadsheetId.with(VALUE),
-                "" + VALUE);
+                Long.toHexString(VALUE));
     }
 
     @Override
@@ -100,5 +112,22 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
     @Override
     public SpreadsheetId fromJsonNode(final JsonNode node) {
         return SpreadsheetId.fromJsonNode(node);
+    }
+
+    // ParseStringTesting...............................................................................................
+
+    @Override
+    public SpreadsheetId parse(final String text) {
+        return SpreadsheetId.parse(text);
+    }
+
+    @Override
+    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> type) {
+        return type;
+    }
+
+    @Override
+    public RuntimeException parseFailedExpected(final RuntimeException cause) {
+        return cause;
     }
 }


### PR DESCRIPTION
- MemorySpreadsheetContextTest links include /cell/$spreadsheet/copy and not $cell-ref