### PR TITLE
BigDecimalSpreadsheetTextFormatter parameter MathContext removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/format/BigDecimalSpreadsheetTextFormatter.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/BigDecimalSpreadsheetTextFormatter.java
@@ -21,34 +21,30 @@ import walkingkooka.color.Color;
 import walkingkooka.spreadsheet.format.parser.SpreadsheetFormatBigDecimalParserToken;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
- * A {@link SpreadsheetTextFormatter} that unconditionally formats a {@link BigDecimal}, without a {@link Color}.
+ * A {@link SpreadsheetTextFormatter} that unconditionally formats a {@link BigDecimal} using a pattern, without a {@link Color}.
+ * The pattern would have been a {@link String} but the factory accepts it represented as a {@link SpreadsheetFormatBigDecimalParserToken}.
  */
 final class BigDecimalSpreadsheetTextFormatter extends SpreadsheetTextFormatter3<BigDecimal, SpreadsheetFormatBigDecimalParserToken> {
 
     /**
      * Creates a {@link BigDecimalSpreadsheetTextFormatter} from a {@link SpreadsheetFormatBigDecimalParserToken}.
      */
-    static BigDecimalSpreadsheetTextFormatter with(final SpreadsheetFormatBigDecimalParserToken token,
-                                                   final MathContext mathContext) {
+    static BigDecimalSpreadsheetTextFormatter with(final SpreadsheetFormatBigDecimalParserToken token) {
         check(token);
-        Objects.requireNonNull(mathContext, "mathContext");
 
-        return new BigDecimalSpreadsheetTextFormatter(token, mathContext);
+        return new BigDecimalSpreadsheetTextFormatter(token);
     }
 
     /**
      * Private ctor use static parse.
      */
-    private BigDecimalSpreadsheetTextFormatter(final SpreadsheetFormatBigDecimalParserToken token, final MathContext mathContext) {
+    private BigDecimalSpreadsheetTextFormatter(final SpreadsheetFormatBigDecimalParserToken token) {
         super(token);
 
-        this.mathContext = mathContext;
 
         final BigDecimalSpreadsheetTextFormatterSpreadsheetFormatParserTokenVisitor visitor =
                 BigDecimalSpreadsheetTextFormatterSpreadsheetFormatParserTokenVisitor.analyze(token);
@@ -64,6 +60,9 @@ final class BigDecimalSpreadsheetTextFormatter extends SpreadsheetTextFormatter3
         this.thousandsSeparator = visitor.thousandsSeparator;
     }
 
+    /**
+     * Only accepts {@link BigDecimal} values for formatting.
+     */
     @Override
     public Class<BigDecimal> type() {
         return BigDecimal.class;
@@ -84,14 +83,10 @@ final class BigDecimalSpreadsheetTextFormatter extends SpreadsheetTextFormatter3
     }
 
     /**
-     * A non zero value multiplied against the {@link BigDecimal} being formatted as text.
+     * A non zero value multiplied against the {@link BigDecimal} being formatted as text. This is typically one, but
+     * if a percentage was included in the pattern it will be 100 etc.
      */
     final BigDecimal multiplier;
-
-    /**
-     * Used when the multiplier is applied to the {@link BigDecimal} being formatted as text.
-     */
-    final MathContext mathContext;
 
     /**
      * Components for each symbol in the original pattern.
@@ -105,7 +100,7 @@ final class BigDecimalSpreadsheetTextFormatter extends SpreadsheetTextFormatter3
     /**
      * When true thousands separators should appear in the output.
      */
-    final BigDecimalSpreadsheetTextFormatterThousandsSeparator thousandsSeparator;
+    private final BigDecimalSpreadsheetTextFormatterThousandsSeparator thousandsSeparator;
 
     @Override
     String toStringSuffix() {

--- a/src/main/java/walkingkooka/spreadsheet/format/BigDecimalSpreadsheetTextFormatterFormat.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/BigDecimalSpreadsheetTextFormatterFormat.java
@@ -35,7 +35,7 @@ enum BigDecimalSpreadsheetTextFormatterFormat {
                                                                    final BigDecimalSpreadsheetTextFormatter formatter,
                                                                    final SpreadsheetTextFormatContext context) {
 
-            final BigDecimal rounded = value.multiply(formatter.multiplier, formatter.mathContext)
+            final BigDecimal rounded = value.multiply(formatter.multiplier, context.mathContext())
                     .setScale(formatter.fractionDigitSymbolCount, RoundingMode.HALF_UP);
 
             final int valueSign = rounded.signum();

--- a/src/main/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetTextFormatterSpreadsheetFormatParserTokenVisitor.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetTextFormatterSpreadsheetFormatParserTokenVisitor.java
@@ -79,7 +79,7 @@ final class ExpressionSpreadsheetTextFormatterSpreadsheetFormatParserTokenVisito
 
     @Override
     protected void endVisit(final SpreadsheetFormatBigDecimalParserToken token) {
-        this.setSpreadsheetTextFormatter(SpreadsheetTextFormatters.bigDecimal(token, this.mathContext), token);
+        this.setSpreadsheetTextFormatter(SpreadsheetTextFormatters.bigDecimal(token), token);
     }
 
     @Override

--- a/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetTextFormatters.java
+++ b/src/main/java/walkingkooka/spreadsheet/format/SpreadsheetTextFormatters.java
@@ -41,9 +41,8 @@ public final class SpreadsheetTextFormatters implements PublicStaticHelper {
     /**
      * {@see BigDecimalSpreadsheetTextFormatter}
      */
-    public static SpreadsheetTextFormatter<BigDecimal> bigDecimal(final SpreadsheetFormatBigDecimalParserToken token,
-                                                                  final MathContext mathContext) {
-        return BigDecimalSpreadsheetTextFormatter.with(token, mathContext);
+    public static SpreadsheetTextFormatter<BigDecimal> bigDecimal(final SpreadsheetFormatBigDecimalParserToken token) {
+        return BigDecimalSpreadsheetTextFormatter.with(token);
     }
 
     /**

--- a/src/test/java/walkingkooka/spreadsheet/format/BigDecimalSpreadsheetTextFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/BigDecimalSpreadsheetTextFormatterTest.java
@@ -1221,7 +1221,7 @@ public final class BigDecimalSpreadsheetTextFormatterTest extends SpreadsheetTex
 
     @Override
     BigDecimalSpreadsheetTextFormatter createFormatter0(final SpreadsheetFormatBigDecimalParserToken token) {
-        return BigDecimalSpreadsheetTextFormatter.with(token, MathContext.UNLIMITED);
+        return BigDecimalSpreadsheetTextFormatter.with(token);
     }
 
     @Override
@@ -1250,6 +1250,11 @@ public final class BigDecimalSpreadsheetTextFormatterTest extends SpreadsheetTex
             @Override
             public char groupingSeparator() {
                 return 'G';
+            }
+
+            @Override
+            public MathContext mathContext() {
+                return MathContext.UNLIMITED;
             }
 
             @Override

--- a/src/test/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetTextFormatterTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/ExpressionSpreadsheetTextFormatterTest.java
@@ -319,6 +319,11 @@ public final class ExpressionSpreadsheetTextFormatterTest extends SpreadsheetTex
             }
 
             @Override
+            public MathContext mathContext() {
+                return MATH_CONTEXT;
+            }
+
+            @Override
             public char minusSign() {
                 return '-';
             }


### PR DESCRIPTION
- Changed to use context MathContext rather than previous field.