### PR TITLE
SpreadsheetContext.generalDecimalFormatPattern removed

### DIFF
--- a/src/main/java/walkingkooka/spreadsheet/context/FakeSpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/FakeSpreadsheetContext.java
@@ -66,11 +66,6 @@ public class FakeSpreadsheetContext implements SpreadsheetContext {
     }
 
     @Override
-    public String generalDecimalFormatPattern(final SpreadsheetId id) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>> hateosRouter(final SpreadsheetId id) {
         throw new UnsupportedOperationException();
     }

--- a/src/main/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContext.java
@@ -87,7 +87,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
                                                                       final Function<SpreadsheetId, DecimalNumberContext> spreadsheetIdDecimalNumberContext,
                                                                       final Function<SpreadsheetId, SpreadsheetTextFormatter> spreadsheetIdDefaultSpreadsheetTextFormatter,
                                                                       final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                                                                      final Function<SpreadsheetId, String> spreadsheetIdGeneralDecimalFormatPattern,
                                                                       final Function<SpreadsheetId, Function<String, Optional<Color>>> spreadsheetIdNameToColor,
                                                                       final Function<SpreadsheetId, Function<Integer, Optional<Color>>> spreadsheetIdNumberToColor,
                                                                       final Function<SpreadsheetId, Integer> spreadsheetIdWidth) {
@@ -100,7 +99,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
         Objects.requireNonNull(spreadsheetIdDecimalNumberContext, "spreadsheetIdDecimalNumberContext");
         Objects.requireNonNull(spreadsheetIdDefaultSpreadsheetTextFormatter, "spreadsheetIdDefaultSpreadsheetTextFormatter");
         Objects.requireNonNull(spreadsheetIdFunctions, "spreadsheetIdFunctions");
-        Objects.requireNonNull(spreadsheetIdGeneralDecimalFormatPattern, "spreadsheetIdGeneralDecimalFormatPattern");
         Objects.requireNonNull(spreadsheetIdNameToColor, "spreadsheetIdNameToColor");
         Objects.requireNonNull(spreadsheetIdNumberToColor, "spreadsheetIdNumberToColor");
         Objects.requireNonNull(spreadsheetIdWidth, "spreadsheetIdWidth");
@@ -114,7 +112,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
                 spreadsheetIdDecimalNumberContext,
                 spreadsheetIdDefaultSpreadsheetTextFormatter,
                 spreadsheetIdFunctions,
-                spreadsheetIdGeneralDecimalFormatPattern,
                 spreadsheetIdNameToColor,
                 spreadsheetIdNumberToColor,
                 spreadsheetIdWidth);
@@ -129,7 +126,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
                                      final Function<SpreadsheetId, DecimalNumberContext> spreadsheetIdDecimalNumberContext,
                                      final Function<SpreadsheetId, SpreadsheetTextFormatter> spreadsheetIdDefaultSpreadsheetTextFormatter,
                                      final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                                     final Function<SpreadsheetId, String> spreadsheetIdGeneralDecimalFormatPattern,
                                      final Function<SpreadsheetId, Function<String, Optional<Color>>> spreadsheetIdNameToColor,
                                      final Function<SpreadsheetId, Function<Integer, Optional<Color>>> spreadsheetIdNumberToColor,
                                      final Function<SpreadsheetId, Integer> spreadsheetIdWidth) {
@@ -145,7 +141,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
         this.spreadsheetIdDecimalNumberContext = spreadsheetIdDecimalNumberContext;
         this.spreadsheetIdDefaultSpreadsheetTextFormatter = spreadsheetIdDefaultSpreadsheetTextFormatter;
         this.spreadsheetIdFunctions = spreadsheetIdFunctions;
-        this.spreadsheetIdGeneralDecimalFormatPattern = spreadsheetIdGeneralDecimalFormatPattern;
         this.spreadsheetIdNameToColor = spreadsheetIdNameToColor;
         this.spreadsheetIdNumberToColor = spreadsheetIdNumberToColor;
         this.spreadsheetIdWidth = spreadsheetIdWidth;
@@ -185,13 +180,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
     }
 
     private final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions;
-
-    @Override
-    public String generalDecimalFormatPattern(final SpreadsheetId id) {
-        return this.spreadsheetIdGeneralDecimalFormatPattern.apply(id);
-    }
-
-    private final Function<SpreadsheetId, String> spreadsheetIdGeneralDecimalFormatPattern;
 
     // hateosRouter.....................................................................................................
 
@@ -238,7 +226,6 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
         final BiFunction<ExpressionNodeName, List<Object>, Object> functions = this.spreadsheetIdFunctions.apply(id);
         final Function<Integer, Optional<Color>> numberToColor = this.spreadsheetIdNumberToColor.apply(id);
         final Function<String, Optional<Color>> nameToColor = this.spreadsheetIdNameToColor.apply(id);
-        final String generalDecimalFormatPattern = this.spreadsheetIdGeneralDecimalFormatPattern.apply(id);
         final int width = this.spreadsheetIdWidth.apply(id);
         final Function<BigDecimal, Fraction> fractioner = this.fractioner;
         final SpreadsheetTextFormatter defaultSpreadsheetTextFormatter = this.defaultSpreadsheetTextFormatter(id);
@@ -251,7 +238,7 @@ final class MemorySpreadsheetContext<N extends Node<N, ?, ?, ?>> implements Spre
                 this.dateTimeContext(id),
                 numberToColor,
                 nameToColor,
-                generalDecimalFormatPattern,
+                "#.00",
                 width,
                 fractioner,
                 defaultSpreadsheetTextFormatter);

--- a/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContext.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContext.java
@@ -75,11 +75,6 @@ public interface SpreadsheetContext extends Context {
     BiFunction<ExpressionNodeName, List<Object>, Object> functions(final SpreadsheetId id);
 
     /**
-     * Returns a {@link String general decimal format pattern} for the given {@link SpreadsheetId}.
-     */
-    String generalDecimalFormatPattern(final SpreadsheetId id);
-
-    /**
      * A {@link Router} that can handle hateos requests for the given identified spreadsheet.
      */
     Router<HttpRequestAttribute<?>, BiConsumer<HttpRequest, HttpResponse>> hateosRouter(final SpreadsheetId id);

--- a/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContextTesting.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContextTesting.java
@@ -55,13 +55,6 @@ public interface SpreadsheetContextTesting<C extends SpreadsheetContext> extends
     }
 
     @Test
-    default void testGeneralDecimalFormatPatternNullSpreadsheetIdFails() {
-        assertThrows(NullPointerException.class, () -> {
-            this.createContext().generalDecimalFormatPattern(null);
-        });
-    }
-
-    @Test
     default void testHateosRouterNullSpreadsheetIdFails() {
         assertThrows(NullPointerException.class, () -> {
             this.createContext().hateosRouter(null);

--- a/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContexts.java
+++ b/src/main/java/walkingkooka/spreadsheet/context/SpreadsheetContexts.java
@@ -59,7 +59,6 @@ public final class SpreadsheetContexts implements PublicStaticHelper {
                                                                          final Function<SpreadsheetId, DecimalNumberContext> spreadsheetIdDecimalNumberContext,
                                                                          final Function<SpreadsheetId, SpreadsheetTextFormatter> spreadsheetIdDefaultSpreadsheetTextFormatter,
                                                                          final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                                                                         final Function<SpreadsheetId, String> spreadsheetIdGeneralDecimalFormatPattern,
                                                                          final Function<SpreadsheetId, Function<String, Optional<Color>>> spreadsheetIdNameToColor,
                                                                          final Function<SpreadsheetId, Function<Integer, Optional<Color>>> spreadsheetIdNumberToColor,
                                                                          final Function<SpreadsheetId, Integer> spreadsheetIdWidth) {
@@ -72,7 +71,6 @@ public final class SpreadsheetContexts implements PublicStaticHelper {
                 spreadsheetIdDecimalNumberContext,
                 spreadsheetIdDefaultSpreadsheetTextFormatter,
                 spreadsheetIdFunctions,
-                spreadsheetIdGeneralDecimalFormatPattern,
                 spreadsheetIdNameToColor,
                 spreadsheetIdNumberToColor,
                 spreadsheetIdWidth);

--- a/src/test/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContextTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/context/MemorySpreadsheetContextTest.java
@@ -93,7 +93,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -110,7 +109,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -127,7 +125,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -144,7 +141,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -161,7 +157,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -178,7 +173,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -195,7 +189,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 null,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -212,7 +205,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 null,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -229,24 +221,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 null,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
-                this::spreadsheetIdNameToColor,
-                this::spreadsheetIdNumberToColor,
-                this::spreadsheetIdWidth);
-    }
-
-    @Test
-    public void testWithNullSpreadsheetIdGeneralDecimalFormatPatternFails() {
-        this.withFails(this.base(),
-                this.contentType(),
-                this::fractioner,
-                this::metadataWithDefaults,
-                this::spreadsheetIdConverter,
-                this::spreadsheetIdDateTimeContext,
-                this::spreadsheetIdDecimalNumberContext,
-                this::spreadsheetIdDefaultSpreadsheetTextFormatter,
-                this::spreadsheetIdFunctions,
-                null,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -263,7 +237,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 null,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -280,7 +253,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 null,
                 this::spreadsheetIdWidth);
@@ -297,7 +269,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 null);
@@ -312,7 +283,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                            final Function<SpreadsheetId, DecimalNumberContext> spreadsheetIdDecimalNumberContext,
                            final Function<SpreadsheetId, SpreadsheetTextFormatter> spreadsheetIdDefaultSpreadsheetTextFormatter,
                            final Function<SpreadsheetId, BiFunction<ExpressionNodeName, List<Object>, Object>> spreadsheetIdFunctions,
-                           final Function<SpreadsheetId, String> spreadsheetIdGeneralDecimalFormatPattern,
                            final Function<SpreadsheetId, Function<String, Optional<Color>>> spreadsheetIdNameToColor,
                            final Function<SpreadsheetId, Function<Integer, Optional<Color>>> spreadsheetIdNumberToColor,
                            final Function<SpreadsheetId, Integer> spreadsheetIdWidth) {
@@ -326,7 +296,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                     spreadsheetIdDecimalNumberContext,
                     spreadsheetIdDefaultSpreadsheetTextFormatter,
                     spreadsheetIdFunctions,
-                    spreadsheetIdGeneralDecimalFormatPattern,
                     spreadsheetIdNameToColor,
                     spreadsheetIdNumberToColor,
                     spreadsheetIdWidth);
@@ -356,11 +325,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
     @Test
     public void testFunctions() {
         assertNotEquals(null, this.createContext().functions(this.spreadsheetId()));
-    }
-
-    @Test
-    public void testGeneralDecimalFormatPattern() {
-        assertNotEquals(null, this.createContext().generalDecimalFormatPattern(this.spreadsheetId()));
     }
 
     @Test
@@ -455,7 +419,7 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    },\n" +
                         "    \"formatted\": {\n" +
                         "      \"type\": \"text\",\n" +
-                        "      \"value\": \"Hello1233\"\n" +
+                        "      \"value\": \"3.00\"\n" +
                         "    }\n" +
                         "  }],\n" +
                         "  \"_links\": [{\n" +
@@ -521,7 +485,7 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    },\n" +
                         "    \"formatted\": {\n" +
                         "      \"type\": \"text\",\n" +
-                        "      \"value\": \"Hello1233\"\n" +
+                        "      \"value\": \"3.00\"\n" +
                         "    }\n" +
                         "  }],\n" +
                         "  \"_links\": [{\n" +
@@ -587,7 +551,7 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                         "    },\n" +
                         "    \"formatted\": {\n" +
                         "      \"type\": \"text\",\n" +
-                        "      \"value\": \"Hello1233\"\n" +
+                        "      \"value\": \"3.00\"\n" +
                         "    }\n" +
                         "  }],\n" +
                         "  \"_links\": [{\n" +
@@ -853,7 +817,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
                 this::spreadsheetIdDecimalNumberContext,
                 this::spreadsheetIdDefaultSpreadsheetTextFormatter,
                 this::spreadsheetIdFunctions,
-                this::spreadsheetIdGeneralDecimalFormatPattern,
                 this::spreadsheetIdNameToColor,
                 this::spreadsheetIdNumberToColor,
                 this::spreadsheetIdWidth);
@@ -903,12 +866,6 @@ public final class MemorySpreadsheetContextTest implements SpreadsheetContextTes
 
     private Object spreadsheetIdFunctions(final ExpressionNodeName functionName, final List<Object> parameters) {
         throw new UnsupportedOperationException(functionName + "(" + parameters + ")");
-    }
-
-    private String spreadsheetIdGeneralDecimalFormatPattern(final SpreadsheetId spreadsheetId) {
-        this.checkSpreadsheetId(spreadsheetId);
-
-        return "Hello123";
     }
 
     private SpreadsheetMetadata metadataWithDefaults(final Optional<Locale> locale) {


### PR DESCRIPTION
- MemorySpreadsheetContext uses hard coded literal when creating SpreadsheetEngineContext