### PR TITLE
walkingkooka 2f83b92f7b9cff43f6b5359dd7fbfc6202ade410 20190809

### DIFF
--- a/src/test/java/walkingkooka/spreadsheet/SpreadsheetIdTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/SpreadsheetIdTest.java
@@ -55,16 +55,16 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
         this.hateosLinkIdAndCheck(SpreadsheetId.with(0x1f), "1f");
     }
 
-    // Parse............................................................................................................
+    // ParseString............................................................................................................
 
     @Test
     public void testParseInvalidFails() {
-        this.parseFails("XYZ", IllegalArgumentException.class);
+        this.parseStringFails("XYZ", IllegalArgumentException.class);
     }
 
     @Test
     public void testParse() {
-        this.parseAndCheck("1A", SpreadsheetId.with(0x1a));
+        this.parseStringAndCheck("1A", SpreadsheetId.with(0x1a));
     }
 
     @Test
@@ -163,20 +163,20 @@ public final class SpreadsheetIdTest implements ClassTesting2<SpreadsheetId>,
         return SpreadsheetId.fromJsonNode(node);
     }
 
-    // ParseStringTesting...............................................................................................
+    // ParseStringStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetId parse(final String text) {
+    public SpreadsheetId parseString(final String text) {
         return SpreadsheetId.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> type) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> type) {
         return type;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException cause) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException cause) {
         return cause;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetDatePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetDatePatternsTest.java
@@ -105,13 +105,13 @@ public final class SpreadsheetDatePatternsTest extends SpreadsheetPatternsTestCa
     // Parse............................................................................................................
 
     @Test
-    public void testParseDateTimePatternFails() {
-        this.parseFails("ddmmyyyy hhmmss", IllegalArgumentException.class);
+    public void testParseStringDateTimePatternFails() {
+        this.parseStringFails("ddmmyyyy hhmmss", IllegalArgumentException.class);
     }
 
     @Test
-    public void testParseNumberPatternFails() {
-        this.parseFails("0#00", IllegalArgumentException.class);
+    public void testParseStringNumberPatternFails() {
+        this.parseStringFails("0#00", IllegalArgumentException.class);
     }
 
     // helpers.........................................................................................................
@@ -158,7 +158,7 @@ public final class SpreadsheetDatePatternsTest extends SpreadsheetPatternsTestCa
     // ParseStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetDatePatterns parse(final String text) {
+    public SpreadsheetDatePatterns parseString(final String text) {
         return SpreadsheetDatePatterns.parseDate(text);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetDateTimePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetDateTimePatternsTest.java
@@ -77,11 +77,11 @@ public final class SpreadsheetDateTimePatternsTest extends SpreadsheetPatternsTe
         this.withInvalidCharacterFails(this.time());
     }
 
-    // Parse............................................................................................................
+    // ParseString............................................................................................................
 
     @Test
-    public void testParseNumberPatternFails() {
-        this.parseFails("0#00", IllegalArgumentException.class);
+    public void testParseStringNumberPatternFails() {
+        this.parseStringFails("0#00", IllegalArgumentException.class);
     }
 
     // helpers.........................................................................................................
@@ -128,7 +128,7 @@ public final class SpreadsheetDateTimePatternsTest extends SpreadsheetPatternsTe
     // ParseStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetDateTimePatterns parse(final String text) {
+    public SpreadsheetDateTimePatterns parseString(final String text) {
         return SpreadsheetDateTimePatterns.parseDateTime(text);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetNumberPatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetNumberPatternsTest.java
@@ -75,18 +75,18 @@ public final class SpreadsheetNumberPatternsTest extends SpreadsheetPatternsTest
     // Parse............................................................................................................
 
     @Test
-    public void testParseDatePatternFails() {
-        this.parseFails("dd/mm/yyyy", IllegalArgumentException.class);
+    public void testParseStringDatePatternFails() {
+        this.parseStringFails("dd/mm/yyyy", IllegalArgumentException.class);
     }
 
     @Test
-    public void testParseDateTimePatternFails() {
-        this.parseFails("dd/mm/yyyy hh:mm:sss", IllegalArgumentException.class);
+    public void testParseStringDateTimePatternFails() {
+        this.parseStringFails("dd/mm/yyyy hh:mm:sss", IllegalArgumentException.class);
     }
 
     @Test
-    public void testParseTimePatternFails() {
-        this.parseFails("hh:mm:sss", IllegalArgumentException.class);
+    public void testParseStringTimePatternFails() {
+        this.parseStringFails("hh:mm:sss", IllegalArgumentException.class);
     }
 
     // helpers.........................................................................................................
@@ -133,7 +133,7 @@ public final class SpreadsheetNumberPatternsTest extends SpreadsheetPatternsTest
     // ParseStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetNumberPatterns parse(final String text) {
+    public SpreadsheetNumberPatterns parseString(final String text) {
         return SpreadsheetNumberPatterns.parseNumber(text);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternsTestCase.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetPatternsTestCase.java
@@ -274,34 +274,34 @@ public abstract class SpreadsheetPatternsTestCase<P extends SpreadsheetPatterns<
     // Parse............................................................................................................
 
     @Test
-    public final void testParseIllegalPatternFails() {
-        this.parseFails("\"unclosed quoted text inside patterns", IllegalArgumentException.class);
+    public final void testParseStringIllegalPatternFails() {
+        this.parseStringFails("\"unclosed quoted text inside patterns", IllegalArgumentException.class);
     }
 
     @Test
-    public final void testParseHangingSeparatorFails() {
-        this.parseFails(this.patternText() + ";", IllegalArgumentException.class);
+    public final void testParseStringHangingSeparatorFails() {
+        this.parseStringFails(this.patternText() + ";", IllegalArgumentException.class);
     }
 
     @Test
-    public final void testParseGeneralFails() {
-        this.parseFails("General", IllegalArgumentException.class);
+    public final void testParseStringGeneralFails() {
+        this.parseStringFails("General", IllegalArgumentException.class);
     }
 
     @Test
-    public final void testParse() {
+    public final void testParseString() {
         final String patternText = this.patternText();
 
-        this.parseAndCheck(patternText,
+        this.parseStringAndCheck(patternText,
                 this.createPattern(Lists.of(this.parseParserToken(patternText))));
     }
 
     @Test
-    public final void testParseSeveralTokens() {
+    public final void testParseStringSeveralTokens() {
         final String patternText = "\"text-literal-123\"";
         final String patternText2 = this.patternText();
 
-        this.parseAndCheck(patternText + ";" + patternText2,
+        this.parseStringAndCheck(patternText + ";" + patternText2,
                 this.createPattern(Lists.of(parseParserToken(patternText), parseParserToken(patternText2))));
     }
 
@@ -394,12 +394,12 @@ public abstract class SpreadsheetPatternsTestCase<P extends SpreadsheetPatterns<
     // ParseStringTesting...............................................................................................
 
     @Override
-    public final Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public final Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public final RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public final RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetTextFormatterPatternTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetTextFormatterPatternTest.java
@@ -52,11 +52,11 @@ public final class SpreadsheetTextFormatterPatternTest implements ClassTesting2<
         assertEquals(with.value(), pattern.value(), "value");
     }
 
-    // Parse............................................................................................................
+    // ParseString.......................................................................................................
 
     @Test
-    public void testParseIllegalPatternFails() {
-        this.parseFails("\"unclosed quoted text inside patterns", IllegalArgumentException.class);
+    public void testParseStringIllegalPatternFails() {
+        this.parseStringFails("\"unclosed quoted text inside patterns", IllegalArgumentException.class);
     }
 
     @Test
@@ -124,17 +124,17 @@ public final class SpreadsheetTextFormatterPatternTest implements ClassTesting2<
     // ParseStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetTextFormatterPattern parse(final String text) {
+    public SpreadsheetTextFormatterPattern parseString(final String text) {
         return SpreadsheetTextFormatterPattern.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetTimePatternsTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/format/SpreadsheetTimePatternsTest.java
@@ -90,13 +90,13 @@ public final class SpreadsheetTimePatternsTest extends SpreadsheetPatternsTestCa
     // Parse............................................................................................................
 
     @Test
-    public void testParseDatePatternFails() {
-        this.parseFails("ddmmyyyy", IllegalArgumentException.class);
+    public void testParseStringDatePatternFails() {
+        this.parseStringFails("ddmmyyyy", IllegalArgumentException.class);
     }
 
     @Test
-    public void testParseNumberPatternFails() {
-        this.parseFails("0#00", IllegalArgumentException.class);
+    public void testParseStringNumberPatternFails() {
+        this.parseStringFails("0#00", IllegalArgumentException.class);
     }
 
     // helpers.........................................................................................................
@@ -143,7 +143,7 @@ public final class SpreadsheetTimePatternsTest extends SpreadsheetPatternsTestCa
     // ParseStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetTimePatterns parse(final String text) {
+    public SpreadsheetTimePatterns parseString(final String text) {
         return SpreadsheetTimePatterns.parseTime(text);
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetCellReferenceTest.java
@@ -338,20 +338,20 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetExpressionRef
 
     @Test
     public void testParseInvalidCellReferenceFails() {
-        this.parseFails("Invalid",
+        this.parseStringFails("Invalid",
                 IllegalArgumentException.class);
     }
 
     @Test
     public void testParseCellReferenceRelative() {
-        this.parseAndCheck("A98",
+        this.parseStringAndCheck("A98",
                 SpreadsheetColumnReference.with(0, SpreadsheetReferenceKind.RELATIVE)
                         .setRow(SpreadsheetRowReference.with(97, SpreadsheetReferenceKind.RELATIVE)));
     }
 
     @Test
     public void testParseCellReferenceAbsolute() {
-        this.parseAndCheck("$A$98",
+        this.parseStringAndCheck("$A$98",
                 SpreadsheetColumnReference.with(0, SpreadsheetReferenceKind.ABSOLUTE)
                         .setRow(SpreadsheetRowReference.with(97, SpreadsheetReferenceKind.ABSOLUTE)));
     }
@@ -575,17 +575,17 @@ public final class SpreadsheetCellReferenceTest extends SpreadsheetExpressionRef
     // ParseStringTesting.........................................................................................
 
     @Override
-    public SpreadsheetCellReference parse(final String text) {
+    public SpreadsheetCellReference parseString(final String text) {
         return SpreadsheetExpressionReference.parseCellReference(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetColumnReferenceTest.java
@@ -92,32 +92,32 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
 
     @Test
     public void testParseEmptyFails() {
-        this.parseFails("", IllegalArgumentException.class);
+        this.parseStringFails("", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseInvalidFails() {
-        this.parseFails("!9", IllegalArgumentException.class);
+        this.parseStringFails("!9", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseAbsolute() {
-        this.parseAndCheck("$A", SpreadsheetReferenceKind.ABSOLUTE.column(0));
+        this.parseStringAndCheck("$A", SpreadsheetReferenceKind.ABSOLUTE.column(0));
     }
 
     @Test
     public void testParseAbsolute2() {
-        this.parseAndCheck("$B", SpreadsheetReferenceKind.ABSOLUTE.column(1));
+        this.parseStringAndCheck("$B", SpreadsheetReferenceKind.ABSOLUTE.column(1));
     }
 
     @Test
     public void testParseRelative() {
-        this.parseAndCheck("A", SpreadsheetReferenceKind.RELATIVE.column(0));
+        this.parseStringAndCheck("A", SpreadsheetReferenceKind.RELATIVE.column(0));
     }
 
     @Test
     public void testParseRelative2() {
-        this.parseAndCheck("B", SpreadsheetReferenceKind.RELATIVE.column(1));
+        this.parseStringAndCheck("B", SpreadsheetReferenceKind.RELATIVE.column(1));
     }
 
     // JsonNodeTesting..................................................................................................
@@ -202,17 +202,17 @@ public final class SpreadsheetColumnReferenceTest extends SpreadsheetColumnOrRow
     // ParseStringTesting............................................................................................
 
     @Override
-    public SpreadsheetColumnReference parse(final String text) {
+    public SpreadsheetColumnReference parseString(final String text) {
         return SpreadsheetColumnReference.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetExpressionReferenceTest.java
@@ -91,13 +91,13 @@ public final class SpreadsheetExpressionReferenceTest implements ClassTesting2<S
     @Test
     public void testParseCellReference() {
         final String reference = "A1";
-        this.parseAndCheck(reference, SpreadsheetExpressionReference.parseCellReference(reference));
+        this.parseStringAndCheck(reference, SpreadsheetExpressionReference.parseCellReference(reference));
     }
 
     @Test
     public void testParseLabel() {
         final String label = "label123";
-        this.parseAndCheck(label, SpreadsheetExpressionReference.labelName(label));
+        this.parseStringAndCheck(label, SpreadsheetExpressionReference.labelName(label));
     }
 
     // ClassTesting.....................................................................................................
@@ -115,17 +115,17 @@ public final class SpreadsheetExpressionReferenceTest implements ClassTesting2<S
     // ParseStringTesting...............................................................................................
 
     @Override
-    public SpreadsheetExpressionReference parse(final String text) {
+    public SpreadsheetExpressionReference parseString(final String text) {
         return SpreadsheetExpressionReference.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(Class<? extends RuntimeException> throwing) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(Class<? extends RuntimeException> throwing) {
         return throwing;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 }

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRangeTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRangeTest.java
@@ -780,32 +780,32 @@ public final class SpreadsheetRangeTest extends SpreadsheetExpressionReferenceTe
 
     @Test
     public void testParseMissingSeparatorSingleton() {
-        this.parseAndCheck("A1", SpreadsheetRange.cellToRange(SpreadsheetExpressionReference.parseCellReference("A1")));
+        this.parseStringAndCheck("A1", SpreadsheetRange.cellToRange(SpreadsheetExpressionReference.parseCellReference("A1")));
     }
 
     @Test
     public void testParseMissingBeginFails() {
-        this.parseFails(":A2", IllegalArgumentException.class);
+        this.parseStringFails(":A2", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseMissingEndFails() {
-        this.parseFails("A2:", IllegalArgumentException.class);
+        this.parseStringFails("A2:", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseInvalidBeginFails() {
-        this.parseFails("##..A2", IllegalArgumentException.class);
+        this.parseStringFails("##..A2", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseInvalidEndFails() {
-        this.parseFails("A1:##", IllegalArgumentException.class);
+        this.parseStringFails("A1:##", IllegalArgumentException.class);
     }
 
     @Test
     public void testParse() {
-        this.parseAndCheck("A1:A2", SpreadsheetRange.with(SpreadsheetExpressionReference.parseCellReference("A1").range(SpreadsheetExpressionReference.parseCellReference("A2"))));
+        this.parseStringAndCheck("A1:A2", SpreadsheetRange.with(SpreadsheetExpressionReference.parseCellReference("A1").range(SpreadsheetExpressionReference.parseCellReference("A2"))));
     }
 
     // HasJsonNode......................................................................................................
@@ -978,17 +978,17 @@ public final class SpreadsheetRangeTest extends SpreadsheetExpressionReferenceTe
     // ParseStringTesting..................................................................................................
 
     @Override
-    public SpreadsheetRange parse(final String text) {
+    public SpreadsheetRange parseString(final String text) {
         return SpreadsheetRange.parseRange0(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> classs) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> classs) {
         return classs;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException cause) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException cause) {
         return cause;
     }
 

--- a/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
+++ b/src/test/java/walkingkooka/spreadsheet/reference/SpreadsheetRowReferenceTest.java
@@ -79,32 +79,32 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
 
     @Test
     public void testParseEmptyFails() {
-        this.parseFails("", IllegalArgumentException.class);
+        this.parseStringFails("", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseInvalidFails() {
-        this.parseFails("!9", IllegalArgumentException.class);
+        this.parseStringFails("!9", IllegalArgumentException.class);
     }
 
     @Test
     public void testParseAbsolute() {
-        this.parseAndCheck("$1", SpreadsheetReferenceKind.ABSOLUTE.row(0));
+        this.parseStringAndCheck("$1", SpreadsheetReferenceKind.ABSOLUTE.row(0));
     }
 
     @Test
     public void testParseAbsolute2() {
-        this.parseAndCheck("$2", SpreadsheetReferenceKind.ABSOLUTE.row(1));
+        this.parseStringAndCheck("$2", SpreadsheetReferenceKind.ABSOLUTE.row(1));
     }
 
     @Test
     public void testParseRelative() {
-        this.parseAndCheck("1", SpreadsheetReferenceKind.RELATIVE.row(0));
+        this.parseStringAndCheck("1", SpreadsheetReferenceKind.RELATIVE.row(0));
     }
 
     @Test
     public void testParseRelative2() {
-        this.parseAndCheck("2", SpreadsheetReferenceKind.RELATIVE.row(1));
+        this.parseStringAndCheck("2", SpreadsheetReferenceKind.RELATIVE.row(1));
     }
 
     // parseRange....................................................................................................
@@ -192,17 +192,17 @@ public final class SpreadsheetRowReferenceTest extends SpreadsheetColumnOrRowRef
     // ParseStringTesting............................................................................................
 
     @Override
-    public SpreadsheetRowReference parse(final String text) {
+    public SpreadsheetRowReference parseString(final String text) {
         return SpreadsheetRowReference.parse(text);
     }
 
     @Override
-    public Class<? extends RuntimeException> parseFailedExpected(final Class<? extends RuntimeException> expected) {
+    public Class<? extends RuntimeException> parseStringFailedExpected(final Class<? extends RuntimeException> expected) {
         return expected;
     }
 
     @Override
-    public RuntimeException parseFailedExpected(final RuntimeException expected) {
+    public RuntimeException parseStringFailedExpected(final RuntimeException expected) {
         return expected;
     }
 }


### PR DESCRIPTION
- https://github.com/mP1/walkingkooka/pull/2087
- ParseStringTesting method names changes avoid ParserTesting clashes